### PR TITLE
Add `$hs->getCustomerRefProxy()` convenience method

### DIFF
--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -408,6 +408,21 @@ final class ApiClient {
 	}
 
 	/**
+	 * Returns a CustomerRef object initialized with the given HelpScout
+	 * Customer ID and email (optional)
+	 *
+	 * @param int $customerId
+	 * @param int $customerEmail
+	 * @return \HelpScout\model\ref\CustomerRef
+	 */
+	public function getCustomerRefProxy($customerId, $customerEmail = false) {
+		$ref = new \HelpScout\model\ref\CustomerRef();
+		$ref->setId($customerId);
+		if ( $customerEmail ) $ref->setEmail($customerEmail);
+		return $ref;
+	}
+
+	/**
 	 * Get a list of Mailboxes for the given user
 	 * @param int $page
 	 * @param string|array $fields


### PR DESCRIPTION
I added this to save a few lines in my integration code and mimic the similar methods right above it, thought others might find it handy. If there are any problems with it please let me know!

For example:

``` php
    // Create the customer reference to associate with the Conversation:
    $customer_ref = $hs->getCustomerRefProxy( $hs_customer_id );
```
