### PR TITLE
Possible vulnerability in isValid() Webhook function

### DIFF
--- a/src/HelpScout/Webhook.php
+++ b/src/HelpScout/Webhook.php
@@ -64,7 +64,7 @@ final class Webhook {
 	 */
 	public function isValid() {
 		$signature = $this->generateSignature();
-		if ($signature == $this->getHeader('HTTP_X_HELPSCOUT_SIGNATURE')) {
+		if (!empty($signature) && $signature == $this->getHeader('HTTP_X_HELPSCOUT_SIGNATURE')) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Check if signature has a valid value in isValid Webhook function, otherwise it's possible that the isValid() function evaluates to true if both the header is not set (and therefore the getHeader return false) and no JSON body is available (and therefore generateSignature() also returns false).

In this case it would be possible to execute code within a isValid() block called from an external source which normally would only be trusted from a Help Scout hook.
