### PR TITLE
API Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/README.md
+++ b/README.md
@@ -167,3 +167,22 @@ if ($webhook->isValid()) {
   } 
 }
 </code></pre>
+
+Debugging
+------------------------
+
+Enable debugging by calling the `setDebug(true)` method. 
+
+The `setDebug` method accepts two parameters: The first is a `boolean` to turn debugging on or off (`true` = on, `false` = off). The second (optional) parameter is a directory in which to save a debug output file. If no directory is passed, the output will echo instead of writing to a log file.
+
+### Example output
+
+```
+[Apr 02 20:54:28] DEBUG: request = {"id":49424262,"firstName":"John","lastName":"Doe","photoUrl":null,"photoType":null,"gender":"unknown","age":null,"organization":null,"jobTitle":null,"location":"Dallas, TX","createdAt":"2015-04-01T18:08:10Z","modifiedAt":"2015-04-02T15:09:37Z","background":null,"address":{"id":5678,"lines":["123 Main Street"],"city":"Dallas","state":"","postalCode":74206,"country":"US","createdAt":null,"modifiedAt":null},"socialProfiles":[],"emails":[],"phones":[],"chats":[],"websites":[]}; context: {"method":"PUT"}
+[Apr 02 20:54:28] DEBUG: response = {"code":400,"error":"Input could not be validated","validationErrors":[{"property":"address:state","value":null,"message":"Value is required"}]}; context: {"method":"PUT"}
+[Apr 02 20:54:28] ERROR: Input could not be validated; context: {"method":"PUT","code":400,"errors":[{"property":"address:state","value":null,"message":"Value is required"}]}
+
+```
+Debug lines consist of four parts: Timestamp `[Apr 02 20:54:28]`, Level `DEBUG`, Message, and Context.
+
+The example above debugging output represents 3 lines of debug text, all occurring within the same API call, a `PUT` method to update a Customer. The first is the request JSON, the second is the response JSON, and the third is an API error and its response from the server.

--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -696,14 +696,14 @@ final class ApiClient {
 			return $responseBody['error'];
 		} elseif (array_key_exists($statusCode, $errorKey)) {
 			return $errorKey[$statusCode];
-		} else {
-			sprintf(
-				'Method %s returned status code %d but we expected code(s) %s', 
-				$type, 
-				$statusCode, 
-				implode(',', $expected)
-			);
 		}
+		
+		return sprintf(
+			'Method %s returned status code %d but we expected code(s) %s', 
+			$type, 
+			$statusCode, 
+			implode(',', $expected)
+		);
 	}
 
 	/**

--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -212,7 +212,7 @@ final class ApiClient {
 	}
 
 	private function getConvoParams(array $params, $fields) {
-		return $this->getParams(array_merge($params, array('fields' => $fields)), array('page','fields','status','modifiedSince'));
+		return $this->getParams(array_merge($params, array('fields' => $fields)), array('page','fields','status','modifiedSince','tag'));
 	}
 
 	/**

--- a/src/HelpScout/ApiException.php
+++ b/src/HelpScout/ApiException.php
@@ -3,4 +3,17 @@ namespace HelpScout;
 
 class ApiException extends \Exception {
 
+	protected $errors = array();
+
+	public function getErrors()
+	{
+		return $this->errors;
+	}
+
+	public function setErrors(array $errors = array())
+	{
+		$this->errors = $errors;
+		return $this;
+	}
+
 }


### PR DESCRIPTION
This PR addresses multiple bugs and improvements.

Issue #13, Commit 1de4ee6c707bda479816c554b477aeaf69eaae08
- Fixed a bug with the `getConvoParams` method that didn't allow `tag` as a valid parameter, thus breaking the `getConversationsForCustomerByMailbox` method, and possibly others as well.

---

Issue #12 is a mismatch validation error where the Java API is more strict that Sumo. This is being addressed. However, this commit (a7028eadd366860ebd9ca8376b0bb3171f3c6da6) replaces generic error messages with direct messages from the API.

- Rewrote the `checkStatus` method to return the full error message from the server if one was passed.
- Created a `getErrorMessage` method to either return a response error message from the server or a default message instead.
- Created a `parseResponse` method that parses the raw server response into an associative array containing the headers and the body content json decoded.
- Removed reference to `CURLOPT_FAILONERROR => true` in publishing methods to the API. This was causing immediate failure and no body to be returned and parsed to get a server error message.
- Converted all references to `checkStatus` to use the parsed response body.

---

Commit 50e449c6d5efa70c2c537b6f903fb6d40198be0a adds verbosity to the API client debugging. [Trello card](https://trello.com/c/0fVo1ion/895-php-api-client-updates)

- Removed duplicated checking of `isDebug` in favor of just calling the `debug` method and letting it decide to write a log or not based on the `isDebug` setting.
- Updated the debug log to include level and context. Levels currently are either `DEBUG` or `ERROR`. Context is extra information passed to the debugger by the ApiClient (ex: 'method', 'error code', 'errors', etc...)

---

Finally, commit 7c9bf563da7257d50dc5bf03f1084e8d0d29158f updates the [README](https://github.com/helpscout/helpscout-api-php/blob/7c9bf563da7257d50dc5bf03f1084e8d0d29158f/README.md#debugging) with a section on debugging.