### PR TITLE
Add Curl abstraction for unit testing and TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,16 @@ php:
   - 5.6
 
 before_install:
-  - composer self-update
-  - composer install --dev -n --prefer-source
+  - travis_retry composer self-update
+  - travis_retry composer install --dev --no-interaction --prefer-source
 
 script:
   - ./vendor/bin/phpunit
+
+after_script:
+  - CODECLIMATE_REPO_TOKEN="b94a19a1f2ecc6c2289f823f994b95b017714b1b7c9d290567446818d1f0988d" ./vendor/bin/test-reporter --stdout > codeclimate.json
+  - "curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.1)' https://codeclimate.com/test_reports"
+
+addons:
+  code_climate:
+    repo_token: b94a19a1f2ecc6c2289f823f994b95b017714b1b7c9d290567446818d1f0988d

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+
+before_install:
+  - composer self-update
+  - composer install --dev -n --prefer-source
+
+script:
+  - ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Help Scout PHP Wrapper
-======================
-PHP Wrapper for the Help Scout API and Webhooks implementation. More information on our developer site: [http://developer.helpscout.net](http://developer.helpscout.net).
+Help Scout PHP Wrapper [![Build Status](https://travis-ci.org/helpscout/helpscout-api-php.svg)](https://travis-ci.org/helpscout/helpscout-api-php)
+================================================================================
+> PHP Wrapper for the Help Scout API and Webhooks implementation. More information on our [developer site](http://developer.helpscout.net).
 
 Version 1.3.11 Released
 ---------------------
@@ -53,7 +53,7 @@ $list = $hs->getConversationsForMailbox(99, array('page' => 2));
 // to get all the closed conversations:
 $closed = $hs->getConversationsForMailbox(99, array('page' => 1, 'status' => 'closed'));
 
-// to get page 2 of a list of conversations, 
+// to get page 2 of a list of conversations,
 // while only returning the "id" and "number" attributes on a conversation:
 $convos = $hs->getConversationsForMailbox(99, array('page' => 2), array('id', 'number'));
 
@@ -98,7 +98,7 @@ When field selectors are used, a JSON object is returned with the specificed fie
 ### Returned JSON
 <pre><code>{
     "name": "My Mailbox",
-    "email": "help@mymailbox.com"	
+    "email": "help@mymailbox.com"
 }
 </code></pre>
 
@@ -164,14 +164,14 @@ if ($webhook->isValid()) {
         $customer = $webhook->getCustomer();
         // do something
         break;
-  } 
+  }
 }
 </code></pre>
 
 Debugging
 ------------------------
 
-Enable debugging by calling the `setDebug(true)` method. 
+Enable debugging by calling the `setDebug(true)` method.
 
 The `setDebug` method accepts two parameters: The first is a `boolean` to turn debugging on or off (`true` = on, `false` = off). The second (optional) parameter is a directory in which to save a debug output file. If no directory is passed, the output will echo instead of writing to a log file.
 

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,19 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.2",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "shuber/curl": "dev-master"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.*",
+        "codeclimate/php-test-reporter": "dev-master"
     },
     "autoload": {
         "psr-0": { "HelpScout\\": "src/" }
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/TestCase.php"
+        ]
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+    <testsuites>
+      <testsuite name="Help Scout PHP API Client">
+        <directory>tests</directory>
+      </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+    </php>
+</phpunit>

--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -496,7 +496,7 @@ final class ApiClient {
 	 * @return void
 	 */
 	public function deleteConversation($id) {
-		$this->doDelete('conversations/' . $id . '.json', 200);
+		return $this->doDelete('conversations/' . $id . '.json', 200);
 	}
 
 	/**
@@ -861,9 +861,10 @@ final class ApiClient {
 		$this->curl->headers = $this->getDefaultCurlHeaders();
 		$this->curl->options = $this->getDefaultCurlOptions();
 		$response = $this->curl->get(self::API_URL . $url, $params);
-		$response->body = json_decode($response->body, true);
+		// Note that doGet doesn't decode here, it returns the actual response
+		// body.
 
-		$this->debug('response = ' . json_encode($response->body), null, array(
+		$this->debug('response = ' . $response->body, null, array(
 			'method' => 'GET',
 			'url'    => $url,
 			'params' => $params
@@ -893,7 +894,7 @@ final class ApiClient {
 		}
 
 		$this->curl->options = $this->getDefaultCurlOptions();
-		$response = $this->curl->post($url, $requestBody);
+		$response = $this->curl->post(self::API_URL . $url, $requestBody);
 		$response->body = json_decode($response->body, true);
 		$this->debug('response = ' . json_encode($response->body), null, array(
 			'method' => 'POST'
@@ -925,13 +926,14 @@ final class ApiClient {
 
 		$this->curl->headers = $this->getDefaultCurlHeaders(strlen($requestBody));
 		$this->curl->options = $this->getDefaultCurlOptions();
-		$response = $this->put(self::API_URL . $url, $requestBody);
+		$response = $this->curl->put(self::API_URL . $url, $requestBody);
 
 		$this->debug('response = ' . json_encode($response->body), null, array(
 			'method' => 'PUT'
 		));
 
 		$this->checkStatus($response->headers['Status-Code'], 'PUT', $expectedCode, $response->body);
+		return true;
 	}
 
     /**
@@ -954,6 +956,7 @@ final class ApiClient {
 		$response->body = json_decode($response->body, true);
 
 		$this->checkStatus($response->headers['Status-Code'], 'DELETE', $expectedCode, $response->body);
+		return true;
 	}
 
 	/**

--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -7,7 +7,7 @@ use HelpScout\model\Attachment;
 
 final class ApiClient {
 	const USER_AGENT = 'Help Scout API/Php Client v1';
-	const API_URL    = 'https://dev-api.helpscout.net/v1/';
+	const API_URL    = 'https://api.helpscout.net/v1/';
 	const NAMESPACE_SEPARATOR = '\\';
 
 	private $userAgent = false;

--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -284,15 +284,15 @@ final class ApiClient {
 		);
 	}
 
-    /**
-     * Gets the User associated with the API key used to make the request.
-     *
-     * @param null $fields
-     * @return \HelpScout\model\User
-     */
-    public function getUserMe($fields=null) {
-        return $this->getItem('users/me.json', $this->getParams(array('fields' => $fields)), 'getUser', '\HelpScout\model\User');
-    }
+	/**
+	 * Gets the User associated with the API key used to make the request.
+	 *
+	 * @param null $fields
+	 * @return \HelpScout\model\User
+	 */
+	public function getUserMe($fields=null) {
+		return $this->getItem('users/me.json', $this->getParams(array('fields' => $fields)), 'getUser', '\HelpScout\model\User');
+	}
 
 	/**
 	 * Returns a Collection of all the customers for the company.
@@ -369,37 +369,37 @@ final class ApiClient {
 		return $this->getCollection("customers.json", $this->getParams($params), 'searchCustomers', '\HelpScout\model\Customer');
 	}
 
-    /**
-     * @param string $query
-     * @param null $sortField
-     * @param null $sortOrder
-     * @param int $page
-     * @return \HelpScout\Collection
-     */
-    public function customerSearch($query='*', $sortField=null, $sortOrder=null, $page=1) {
-        $params = array('query' => $query, 'sortField' => $sortField, 'sortOrder' => $sortOrder, 'page' => $page);
-        return $this->getCollection("search/customers.json", $this->getParams($params), 'customerSearch', '\HelpScout\model\SearchCustomer');
-    }
+	/**
+	 * @param string $query
+	 * @param null $sortField
+	 * @param null $sortOrder
+	 * @param int $page
+	 * @return \HelpScout\Collection
+	 */
+	public function customerSearch($query='*', $sortField=null, $sortOrder=null, $page=1) {
+		$params = array('query' => $query, 'sortField' => $sortField, 'sortOrder' => $sortOrder, 'page' => $page);
+		return $this->getCollection("search/customers.json", $this->getParams($params), 'customerSearch', '\HelpScout\model\SearchCustomer');
+	}
 
-    /**
-     * @param string $query
-     * @param null $sortField
-     * @param null $sortOrder
-     * @param int $page
-     * @return \HelpScout\Collection
-     */
-    public function conversationSearch($query='*', $sortField=null, $sortOrder=null, $page=1) {
-        $params = array('query' => $query, 'sortField' => $sortField, 'sortOrder' => $sortOrder, 'page' => $page);
-        return $this->getCollection("search/customers.json", $this->getParams($params), 'conversationSearch', '\HelpScout\model\SearchConversation');
-    }
+	/**
+	 * @param string $query
+	 * @param null $sortField
+	 * @param null $sortOrder
+	 * @param int $page
+	 * @return \HelpScout\Collection
+	 */
+	public function conversationSearch($query='*', $sortField=null, $sortOrder=null, $page=1) {
+		$params = array('query' => $query, 'sortField' => $sortField, 'sortOrder' => $sortOrder, 'page' => $page);
+		return $this->getCollection("search/customers.json", $this->getParams($params), 'conversationSearch', '\HelpScout\model\SearchConversation');
+	}
 
-    /**
-     * @param  \HelpScout\model\Conversation $conversation
-     * @param boolean $imported
-     * @param boolean $autoReply Enables auto replies to be sent when a conversation is created via the API
-     * @param boolean $reload Return the created conversation in the response
-     * @return boolean|string
-     */
+	/**
+	 * @param  \HelpScout\model\Conversation $conversation
+	 * @param boolean $imported
+	 * @param boolean $autoReply Enables auto replies to be sent when a conversation is created via the API
+	 * @param boolean $reload Return the created conversation in the response
+	 * @return boolean|string
+	 */
 	public function createConversation(model\Conversation $conversation, $imported=false, $autoReply=false, $reload=false) {
 		$url = 'conversations.json';
 		$params = array();
@@ -435,15 +435,15 @@ final class ApiClient {
 		$thread->setId($id);
 	}
 
-    /**
-     * @param $conversationId
-     * @param $threadId
-     * @param $text
-     */
-    public function updateThreadText($conversationId, $threadId, $text) {
-        $json = '{ "body": ' . json_encode($text) . ' }';
-        $this->doPut('conversations/' . $conversationId . '/threads/' . $threadId . '.json', $json, 200);
-    }
+	/**
+	 * @param $conversationId
+	 * @param $threadId
+	 * @param $text
+	 */
+	public function updateThreadText($conversationId, $threadId, $text) {
+		$json = '{ "body": ' . json_encode($text) . ' }';
+		$this->doPut('conversations/' . $conversationId . '/threads/' . $threadId . '.json', $json, 200);
+	}
 
 	/**
 	 * @param  \HelpScout\model\Attachment $attachment
@@ -746,35 +746,6 @@ final class ApiClient {
 	}
 
 	/**
-	 * @param curl   $ch       The cURL object
-	 * @param string $response The raw response to be parsed
-	 *
-	 * @return array
-	 */
-	private function parseResponse($ch, $response)
-	{
-		$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-		$header = substr($response, 0, $header_size);
-		$body = substr($response, $header_size);
-
-		$response = array(
-			'body' => json_decode($body, true)
-		);
-
-		foreach (explode("\r\n", $header) as $i => $line) {
-	        if ($i === 0) {
-	            $headers['http_code'] = $line;
-	        } else {
-	            list ($key, $value) = explode(': ', $line);
-	            $headers[$key] = $value;
-	        }
-	    }
-	    $response['headers'] = $headers;
-
-	    return $response;
-	}
-
-	/**
 	 * @param  array  $params
 	 * @param  array  $accepted
 	 * @return null|array
@@ -813,15 +784,15 @@ final class ApiClient {
 				case 'email':
 					$params[$key] = $val;
 					break;
-                case 'query':
-                    $params[$key] = $val;
-                    break;
-                case 'sortField':
-                    $params[$key] = $val;
-                    break;
-                case 'sortOrder':
-                    $params[$key] = $val;
-                    break;
+				case 'query':
+					$params[$key] = $val;
+					break;
+				case 'sortField':
+					$params[$key] = $val;
+					break;
+				case 'sortOrder':
+					$params[$key] = $val;
+					break;
 				case 'status':
 					if (!in_array($val, array('all','active','pending'))) {
 						unset($params[$key]);
@@ -865,55 +836,6 @@ final class ApiClient {
 		// Location is in the form of /api/model/5345.json and we extract the
 		// id from this location.
 		return pathinfo($location, PATHINFO_FILENAME);
-	}
-
-    /**
-     * @param string $url
-     * @param string $requestBody
-     * @param int $expectedCode
-     * @return void
-     * @throws ApiException
-     */
-	private function doPut($url, $requestBody, $expectedCode) {
-		if (empty($this->apiKey)) {
-			throw new ApiException('Invalid API Key', 401);
-		}
-
-		$this->debug('request = ' . $requestBody, null, array(
-			'method' => 'PUT'
-		));
-
-		$this->curl->headers = $this->getDefaultCurlHeaders(strlen($requestBody));
-		$this->curl->options = $this->getDefaultCurlOptions();
-		$response = $this->put(self::API_URL . $url, $requestBody);
-
-		$this->debug('response = ' . json_encode($response->body), null, array(
-			'method' => 'PUT'
-		));
-
-		$this->checkStatus($response->headers['Status-Code'], 'PUT', $expectedCode, $response->body);
-	}
-
-    /**
-     * @param string $url
-     * @param int $expectedCode
-     * @return void
-     * @throws ApiException
-     */
-	private function doDelete($url, $expectedCode) {
-		if (empty($this->apiKey)) {
-			throw new ApiException('Invalid API Key', 401);
-		}
-
-		$this->debug('request = ' . $url, null, array(
-			'method' => 'DELETE'
-		));
-
-		$this->curl->options = $this->getDefaultCurlOptions();
-		$response = $this->curl->delete(self::API_URL . $url);
-		$response->body = json_decode($response->body, true);
-
-		$this->checkStatus($response->headers['Status-Code'], 'DELETE', $expectedCode, $response->body);
 	}
 
     /**
@@ -983,6 +905,55 @@ final class ApiClient {
 			$this->getIdFromLocation($response->headers['Location']),
 			$response->body
 		);
+	}
+
+    /**
+     * @param string $url
+     * @param string $requestBody
+     * @param int $expectedCode
+     * @return void
+     * @throws ApiException
+     */
+	private function doPut($url, $requestBody, $expectedCode) {
+		if (empty($this->apiKey)) {
+			throw new ApiException('Invalid API Key', 401);
+		}
+
+		$this->debug('request = ' . $requestBody, null, array(
+			'method' => 'PUT'
+		));
+
+		$this->curl->headers = $this->getDefaultCurlHeaders(strlen($requestBody));
+		$this->curl->options = $this->getDefaultCurlOptions();
+		$response = $this->put(self::API_URL . $url, $requestBody);
+
+		$this->debug('response = ' . json_encode($response->body), null, array(
+			'method' => 'PUT'
+		));
+
+		$this->checkStatus($response->headers['Status-Code'], 'PUT', $expectedCode, $response->body);
+	}
+
+    /**
+     * @param string $url
+     * @param int $expectedCode
+     * @return void
+     * @throws ApiException
+     */
+	private function doDelete($url, $expectedCode) {
+		if (empty($this->apiKey)) {
+			throw new ApiException('Invalid API Key', 401);
+		}
+
+		$this->debug('request = ' . $url, null, array(
+			'method' => 'DELETE'
+		));
+
+		$this->curl->options = $this->getDefaultCurlOptions();
+		$response = $this->curl->delete(self::API_URL . $url);
+		$response->body = json_decode($response->body, true);
+
+		$this->checkStatus($response->headers['Status-Code'], 'DELETE', $expectedCode, $response->body);
 	}
 
 	/**

--- a/tests/CreateConversationTest.php
+++ b/tests/CreateConversationTest.php
@@ -1,0 +1,9 @@
+<?php
+class CreateConversationTest extends TestCase {
+    public function testBasicExample()
+    {
+        $this->assertEquals(200, 200);
+    }
+}
+
+/* End of file CreateConversationTest.php */

--- a/tests/CreateConversationTest.php
+++ b/tests/CreateConversationTest.php
@@ -1,9 +1,0 @@
-<?php
-class CreateConversationTest extends TestCase {
-    public function testBasicExample()
-    {
-        $this->assertEquals(200, 200);
-    }
-}
-
-/* End of file CreateConversationTest.php */

--- a/tests/CreateConversationWithNewCustomerTest.php
+++ b/tests/CreateConversationWithNewCustomerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+class CreateConversationWithNewCustomerTest extends TestCase {
+    public function testCanCreateConversation()
+    {
+        $client = $this->getTestClient('CreateConversationWithNewCustomer-201', 'post');
+
+        // The customer associated with the conversation
+        $customerRef = $client->getCustomerRefProxy(null, 'customer@example.com');
+
+        $conversation = new \HelpScout\model\Conversation();
+        $conversation->setType('email');
+        $conversation->setSubject('I need help');
+        $conversation->setCustomer($customerRef);
+        $conversation->setCreatedBy($customerRef);
+
+        // The mailbox associated with the conversation
+        $conversation->setMailbox($client->getMailboxProxy(2562));
+
+        // A conversation must have at least one thread
+        $thread = new \HelpScout\model\thread\Customer();
+        $thread->setBody('Hello there - I need some help please.');
+
+        // Create by: required
+        $thread->setCreatedBy($customerRef);
+        $conversation->addLineItem($thread);
+        $client->createConversation($conversation);
+
+        $this->assertSame('1560125', $conversation->getId(), 'Unable to parse correct conversation id');
+    }
+
+    /**
+     * @expectedException \HelpScout\ApiException
+     */
+    public function testCanFailCreateConversationWithMessage()
+    {
+        $client = $this->getTestClient('CreateConversationWithNewCustomer-400', 'post');
+
+        // The customer associated with the conversation
+        $customerRef = $client->getCustomerRefProxy(null, 'customer@example.com');
+
+        $conversation = new \HelpScout\model\Conversation();
+        $conversation->setCustomer($customerRef);
+        $conversation->setCreatedBy($customerRef);
+        $conversation->setMailbox($client->getMailboxProxy(2562));
+
+        // A conversation must have at least one thread
+        $thread = new \HelpScout\model\thread\Customer();
+
+        // Create by: required
+        $thread->setCreatedBy($customerRef);
+        $conversation->addLineItem($thread);
+        $client->createConversation($conversation);
+    }
+}
+
+/* End of file CreateConversationWithNewCustomerTest.php */

--- a/tests/DeleteConversationTest.php
+++ b/tests/DeleteConversationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class DeleteConversationTest extends TestCase {
+    public function testCanDeleteConversation()
+    {
+        $client = $this->getTestClient('DeleteConversation-200', 'delete');
+        $this->assertTrue($client->deleteConversation(1560007));
+    }
+
+    /**
+     * @expectedException \HelpScout\ApiException
+     */
+    public function testCanFailDeleteConversationWithMessage()
+    {
+        $client = $this->getTestClient('DeleteConversation-404', 'delete');
+        $client->deleteConversation(1560007);
+    }
+}
+
+/* End of file DeleteConversationTest.php */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,31 @@
 <?php
+use HelpScout\ApiClient;
+
 class TestCase extends \PHPUnit_Framework_TestCase
 {
+    public function getTestClient($fixture, $method = 'get')
+    {
+        $client = ApiClient::getInstance();
+        $client->setCurl($this->getCurlMock($fixture, $method));
+        $client->setKey('X');
+        return $client;
+    }
+
+    public function getCurlMock($fixture, $method)
+    {
+        $path = __DIR__ . '/fixtures/' . $fixture . '.json';
+        $data = json_decode(file_get_contents($path), true);
+
+        $curl = $this->getMock('\Curl');
+        $curl
+            ->expects($this->any())
+            ->method($method)
+            ->will($this->returnValue((object) array(
+                'headers' => $data['headers'],
+                'body'    => $data['body']
+            )));
+        return $curl;
+    }
 }
 
 /* End of file TestCase.php */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,6 @@
+<?php
+class TestCase extends \PHPUnit_Framework_TestCase
+{
+}
+
+/* End of file TestCase.php */

--- a/tests/fixtures/CreateConversationWithNewCustomer-201.json
+++ b/tests/fixtures/CreateConversationWithNewCustomer-201.json
@@ -1,0 +1,18 @@
+{
+   "body":"",
+   "headers":{
+      "Http-Version":"1.1",
+      "Status-Code":"201",
+      "Status":"201 Created",
+      "Server":"nginx\/1.4.6 (Ubuntu)",
+      "Date":"Fri, 03 Apr 2015 15:53:39 GMT",
+      "Content-Length":"0",
+      "Connection":"keep-alive",
+      "Access-Control-Allow-Origin":"*",
+      "Location":"http:\/\/dev-api.helpscout.net\/v1\/conversations\/1560125.json",
+      "Access-Control-Allow-Headers":"Origin, X-Requested-With, Content-Type, Accept, Authorization",
+      "Access-Control-Allow-Methods":"GET, POST, PUT, DELETE",
+      "Access-Control-Allow-Credentials":"true",
+      "Strict-Transport-Security":"max-age=31536000; includeSubDomains"
+   }
+}

--- a/tests/fixtures/CreateConversationWithNewCustomer-400.json
+++ b/tests/fixtures/CreateConversationWithNewCustomer-400.json
@@ -1,0 +1,17 @@
+{
+   "body":"{\"code\":400,\"error\":\"Input could not be validated\",\"validationErrors\":[{\"property\":\"mailbox\",\"value\":\"2562545\",\"message\":\"The specified mailbox is not valid\"}]}",
+   "headers":{
+      "Http-Version":"1.1",
+      "Status-Code":"400",
+      "Status":"400 Bad Request",
+      "Server":"nginx\/1.4.6 (Ubuntu)",
+      "Date":"Fri, 03 Apr 2015 15:54:40 GMT",
+      "Content-Type":"application\/json; charset=utf-8",
+      "Content-Length":"160",
+      "Connection":"keep-alive",
+      "Access-Control-Allow-Origin":"*",
+      "Access-Control-Allow-Headers":"Origin, X-Requested-With, Content-Type, Accept, Authorization",
+      "Access-Control-Allow-Methods":"GET, POST, PUT, DELETE",
+      "Access-Control-Allow-Credentials":"true"
+   }
+}

--- a/tests/fixtures/DeleteConversation-200.json
+++ b/tests/fixtures/DeleteConversation-200.json
@@ -1,0 +1,17 @@
+{
+   "body":"",
+   "headers":{
+      "Http-Version":"1.1",
+      "Status-Code":"200",
+      "Status":"200 OK",
+      "Server":"nginx\/1.4.6 (Ubuntu)",
+      "Date":"Mon, 06 Apr 2015 16:48:58 GMT",
+      "Content-Length":"0",
+      "Connection":"keep-alive",
+      "Access-Control-Allow-Origin":"*",
+      "Access-Control-Allow-Headers":"Origin, X-Requested-With, Content-Type, Accept, Authorization",
+      "Access-Control-Allow-Methods":"GET, POST, PUT, DELETE",
+      "Access-Control-Allow-Credentials":"true",
+      "Strict-Transport-Security":"max-age=31536000; includeSubDomains"
+   }
+}

--- a/tests/fixtures/DeleteConversation-404.json
+++ b/tests/fixtures/DeleteConversation-404.json
@@ -1,0 +1,17 @@
+{
+   "body":"{\"code\":404,\"error\":\"The specified conversation was not found: 1560007\"}",
+   "headers":{
+      "Http-Version":"1.1",
+      "Status-Code":"404",
+      "Status":"404 Not Found",
+      "Server":"nginx\/1.4.6 (Ubuntu)",
+      "Date":"Mon, 06 Apr 2015 16:49:51 GMT",
+      "Content-Type":"application\/json; charset=utf-8",
+      "Content-Length":"72",
+      "Connection":"keep-alive",
+      "Access-Control-Allow-Origin":"*",
+      "Access-Control-Allow-Headers":"Origin, X-Requested-With, Content-Type, Accept, Authorization",
+      "Access-Control-Allow-Methods":"GET, POST, PUT, DELETE",
+      "Access-Control-Allow-Credentials":"true"
+   }
+}


### PR DESCRIPTION
This adds a wrapper around Curl so that we can unit test this version of the client. This PR also adds initial TravisCI config to the project. There is some chatter in the diff where I converted spaces to tabs to keep the file consistent, and moved a few methods around to improve organization. Overall though, this disturbs as little code as possible.

This should introduce no new features, however because of a risk of unforeseen issues, this should be a __MINOR__ version number bump.

## Changes

* Add [shuber/curl](https://github.com/shuber/curl) wrapper to allow dependency injection of curl responses.
* Add initial phpunit test files
* Add `phpunit.xml.dist` file
* Add initial `.travis.yml` with testing options

## Risks

This should have minimal risk, but it is a change to the core http interface of the client. I've tested this manually by running each of the example scripts, as well with a new DeleteConversation example script (not included in this PR). I've experienced no issues. The method signatures have not changed for any of the `doVERB()` methods.