### PR TITLE
Changing required version of shuber/curl to at 1.* from dev-master in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.3.2",
         "ext-curl": "*",
-        "shuber/curl": "dev-master"
+        "shuber/curl": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
The shuber/curl version, in composer.json was set to 'dev-master'. By default, Composer doesn't download packages with dev-master version (https://groups.google.com/forum/#!topic/composer-dev/_g3ASeIFlrc/discussion).
shuber/curl now as a 1.0 version so this has been set in composer.json