### PR TITLE
Webhook getcustomer

### DIFF
--- a/src/HelpScout/Webhook.php
+++ b/src/HelpScout/Webhook.php
@@ -114,7 +114,7 @@ final class Webhook {
 	public function getCustomer() {
 		$obj = $this->getObject();
 		if ($obj) {
-			return new \HelpScout\model\Customer($obj);
+			return new \HelpScout\model\Customer($obj->customer);
 		}
 		return false;
 	}


### PR DESCRIPTION
Fix bug in the getCustomer method for Webhook

The data previously sent wasn't customer's data, but the full data received from the webhook.