### PR TITLE
Removed `final` from class declaration

### DIFF
--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -5,7 +5,7 @@ require_once 'ClassLoader.php';
 
 use HelpScout\model\Attachment;
 
-final class ApiClient {
+class ApiClient {
 	const USER_AGENT = 'Help Scout API/Php Client v1';
 	const API_URL    = 'https://api.helpscout.net/v1/';
 	const NAMESPACE_SEPARATOR = '\\';


### PR DESCRIPTION
To allow for people to extend the class, in the event they want to for example use it as the base class for creating a Docs API