### PR TITLE
Fixed the check if the threads exist in the current model instance.

### DIFF
--- a/src/HelpScout/model/Conversation.php
+++ b/src/HelpScout/model/Conversation.php
@@ -587,7 +587,7 @@ class Conversation {
 	 * @return array|null
 	 */
 	public function getThreads($cache = true, $apiCall = true) {
-		if ($this->threads === false && $apiCall) {
+		if ($this->threads === null && $apiCall) {
 			$convo = \HelpScout\ApiClient::getInstance()->getConversation($this->id);
 			if ($convo) {
 				if ($cache) {


### PR DESCRIPTION
The threads attribute is null by default, so the check if ($this->threads === false && $apiCall) would always fail and getThreads() method would always return null.

P.S. Sorry for creating two pull request before this one, I wasn't paying enough attention.
