### PR TITLE
Use hash_equals to prevent possible timing attacks

### DIFF
--- a/examples/dynamic-custom-app.php
+++ b/examples/dynamic-custom-app.php
@@ -32,8 +32,9 @@ class DynamicApp {
 	 */
 	private function isSignatureValid() {
 		$signature = $this->generateSignature();
-		if ($signature) {
-			return $signature === $this->getHeader('HTTP_X_HELPSCOUT_SIGNATURE');
+		$header    = $this->getHeader('HTTP_X_HELPSCOUT_SIGNATURE');
+		if ($signature && $header !== false) {
+            return hash_equals($signature, $header);
 		}
 		return false;
 	}

--- a/src/HelpScout/Webhook.php
+++ b/src/HelpScout/Webhook.php
@@ -9,6 +9,7 @@ final class Webhook {
 
 	public function __construct($secretKey) {
 		\HelpScout\ClassLoader::register();
+        require_once realpath(__DIR__ ."/../HelpScout/functions.php");
 
 		$this->secretKey = $secretKey;
 	}
@@ -82,8 +83,9 @@ final class Webhook {
 	 */
 	public function isValid() {
 		$signature = $this->generateSignature();
-		if ($signature) {
-			return $signature == $this->findHeader(array('HTTP_X_HELPSCOUT_SIGNATURE', 'X_HELPSCOUT_SIGNATURE'));
+        $headers = $this->findHeader(['HTTP_X_HELPSCOUT_SIGNATURE', 'X_HELPSCOUT_SIGNATURE']);
+		if ($signature && $headers !== false) {
+			return hash_equals($signature, $headers);
 		}
 		return false;
 	}

--- a/src/HelpScout/functions.php
+++ b/src/HelpScout/functions.php
@@ -1,0 +1,16 @@
+<?php
+
+// backwards compatibility for old (< 5.6) PHP versions.
+// Comes from http://php.net/manual/en/function.hash-equals.php#115635
+if(!function_exists('hash_equals')) {
+    function hash_equals($str1, $str2) {
+        if(strlen($str1) != strlen($str2)) {
+            return false;
+        } else {
+            $res = $str1 ^ $str2;
+            $ret = 0;
+            for($i = strlen($res) - 1; $i >= 0; $i--) $ret |= ord($res[$i]);
+            return !$ret;
+        }
+    }
+}


### PR DESCRIPTION
- Add functions.php for support for PHP < 5.6
- May want to require functions.php another way (rather than in the Webhook constructor)
