### PR TITLE
decode JSON in response body from PUT requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 1.8.1 (June 13, 2016)
+* Fix issue with setting the value of a dropdown custom field
+* Fix bug in the `getCustomer` method for Webhook
+* Add `status` to `SearchConversation` model
+
 #### 1.8.0 (February 19, 2016)
 * Added support for Custom Fields returned within a Mailbox details
 * Added support for Custom Field Responses returned with a Conversation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Help Scout PHP Wrapper [![Build Status](https://travis-ci.org/helpscout/helpscou
 ================================================================================
 > PHP Wrapper for the Help Scout API and Webhooks implementation. More information on our [developer site](http://developer.helpscout.net).
 
-Version 1.8.0 Released
+Version 1.8.1 Released
 ---------------------
 Please see the [Changelog](https://github.com/helpscout/helpscout-api-php/blob/master/CHANGELOG.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ if ($conversation) {
 // to get page 2 of a list of conversations:
 $list = $hs->getConversationsForMailbox(99, array('page' => 2));
 
-// to get all the closed conversations:
-$closed = $hs->getConversationsForMailbox(99, array('page' => 1, 'status' => 'closed'));
-
 // to get page 2 of a list of conversations,
 // while only returning the "id" and "number" attributes on a conversation:
 $convos = $hs->getConversationsForMailbox(99, array('page' => 2), array('id', 'number'));

--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -964,6 +964,7 @@ final class ApiClient {
 		$this->curl->headers = $this->getDefaultCurlHeaders(strlen($requestBody));
 		$this->curl->options = $this->getDefaultCurlOptions();
 		$response = $this->curl->put(self::API_URL . $url, $requestBody);
+                $response->body = json_decode($response->body, true);
 
 		$this->debug('response = ' . json_encode($response->body), null, array(
 			'method' => 'PUT'


### PR DESCRIPTION
Invalid PUT requests create a catchable fatal error instead of an exception because the response body isn't decoded from JSON:

Catchable fatal error: Argument 4 passed to HelpScout\ApiClient::getErrorMessage() must be of the type array, string given, called in .../helpscout-api-php-master/src/HelpScout/ApiClient.php on line 726 and defined in .../helpscout-api-php-master/src/HelpScout/ApiClient.php on line 756
