### PR TITLE
Fix error message in Message thread model

### DIFF
--- a/src/HelpScout/model/thread/Message.php
+++ b/src/HelpScout/model/thread/Message.php
@@ -13,7 +13,7 @@ class Message extends AbstractThread {
 	public function setCreatedBy(\HelpScout\model\ref\PersonRef $createdBy) {
 		if ($createdBy) {
 			if ($createdBy->getType() !== 'user') {
-				throw new \HelpScout\ApiException('A note thread can only be created by a PersonRef of type user');
+				throw new \HelpScout\ApiException('A message thread can only be created by a PersonRef of type user');
 			}
 		}
 		parent::setCreatedBy($createdBy);


### PR DESCRIPTION
Minor tweak to avoid any confusion when creating a new `Message` thread and the `PersonRef` has a `customer` type instead of `user`.