### PR TITLE
Add method to get existing tags 

### DIFF
--- a/src/HelpScout/ApiClient.php
+++ b/src/HelpScout/ApiClient.php
@@ -288,6 +288,19 @@ final class ApiClient {
 			'users.json', $this->getParams(array('fields' => $fields, 'page' => $page)), 'getUsers', '\HelpScout\model\User'
 		);
 	}
+	
+	/**
+	 * Returns a Collection of all the tags for the company.
+	 *
+	 * @param  integer      $page
+	 * @param  string|array $fields
+	 * @return \HelpScout\Collection
+	 */
+	public function getTags($page=1, $fields=null) {
+		return $this->getCollection(
+			'tags.json', $this->getParams(array('fields' => $fields, 'page' => $page)), 'getTags', '\HelpScout\model\Tag'
+		);
+	}
 
 	/**
 	 * Returns a Collection of users that have access to the given mailbox.

--- a/src/HelpScout/model/Tag.php
+++ b/src/HelpScout/model/Tag.php
@@ -1,0 +1,79 @@
+<?php
+namespace HelpScout\model;
+
+class Tag {
+	private $id = false;
+	private $slug;
+	private $name;
+	private $count;
+	private $color;
+	private $createdAt;
+	private $modifiedAt;
+
+	public function __construct($data=null) {
+		if ($data) {
+			$this->id         = isset($data->id        ) ? $data->id         : null;
+			$this->slug       = isset($data->slug      ) ? $data->slug       : null;
+			$this->name       = isset($data->name      ) ? $data->name       : null;
+			$this->count      = isset($data->count     ) ? $data->count      : null;
+			$this->color      = isset($data->color     ) ? $data->color      : null;
+			$this->createdAt  = isset($data->createdAt ) ? $data->createdAt  : null;
+			$this->modifiedAt = isset($data->modifiedAt) ? $data->modifiedAt : null;
+		}
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSlug() {
+		return $this->slug;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		return $this->Name;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getCount() {
+		return $this->count;
+	}
+
+    /**
+     * @return string
+     */
+    public function getColor() {
+        return $this->color;
+    }
+
+	/**
+	 * @return string
+	 */
+	public function getCreatedAt() {
+		return $this->createdAt;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getModifiedAt() {
+		return $this->modifiedAt;
+	}
+
+	private function isEmpty($value) {
+		$v = trim($value);
+		return empty($v);
+	}
+
+}


### PR DESCRIPTION
I've added the Tag class, and relevant methods, to retrieve a collection of existing tags for a company. 

I have not included a ` toRef()` method for the Tag class because it appears that the API does not currently allow for the creation of new tags or the updating of existing tags. If this is not the case, let me know and I will add the necessary functionality. 