### PR TITLE
Remove php53 from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,5 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-
-allow_failures:
-  - php: 7.0
-  - php: 7.1
-
-before_install:
-  - travis_retry composer self-update
-  - travis_retry composer install --dev --no-interaction --prefer-source
-
-script:
-  - ./vendor/bin/phpunit
-
-after_script:
-  - ./vendor/bin/test-reporter --stdout > codeclimate.json
-  - "curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.1)' https://codeclimate.com/test_reports"
-
 addons:
   code_climate:
     repo_token: $CODECLIMATE_REPO_TOKEN
@@ -30,3 +7,63 @@ addons:
 cache:
   directories:
     - vendor
+    - $HOME/.composer/cache
+
+env:
+  global:
+    - TASK_TESTS_COVERAGE=0
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.4
+
+    - php: 5.5
+
+    - php: 5.6
+      env:
+        - TASK_TESTS_COVERAGE=1
+
+    - php: 7.0
+
+    - php: 7.1
+
+    - php: 7.2
+
+  allow_failures:
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+
+install:
+  # show versions and env information
+  - php --version
+  - composer --version
+  - pg_config --version
+
+  # disable xdebug for performance reasons when code coverage is not needed.
+  - |
+    if [[ $TASK_TESTS_COVERAGE != 1 ]]; then
+      phpenv config-rm xdebug.ini || echo "xdebug is not installed"
+    fi
+
+  # Install dependencies
+  - travis_retry composer self-update
+  - travis_retry composer install --prefer-source --no-interaction --dev
+
+before_script:
+  # Enable code coverage
+  - |
+    if [ $TASK_TESTS_COVERAGE == 1 ]; then
+      PHPUNIT_FLAGS="--coverage-clover=$TRAVIS_BUILD_DIR/build/logs/clover.xml"
+    fi
+
+script:
+  - vendor/bin/phpunit --verbose $PHPUNIT_FLAGS
+
+after_script:
+  - |
+    if [ $TASK_TESTS_COVERAGE == 1 ]; then
+      vendor/bin/test-reporter --stdout > codeclimate.json
+      curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.1)' https://codeclimate.com/test_reports
+    fi

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
         ]
     },
     "minimum-stability": "dev",
-    "prefer-stable" : true
+    "prefer-stable" : true,
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    }
 }


### PR DESCRIPTION
## Problem
After an update today to add a new `LICENSE` file, the build began failing due to php 5.3. Travis no longer supports 5.3 on Trusty and we'd have to do more with the build to make it work.

## Solution
This removes php53 from the build matrix and makes some improvements to the Travis build. In particular it now only runs the code coverage report for a single PHP version and should speed up out runtimes a bit.