### PR TITLE
Remove invalid parameter user from getHappinessReport service definition

### DIFF
--- a/src/HelpScout/descriptions/reports/happiness.php
+++ b/src/HelpScout/descriptions/reports/happiness.php
@@ -31,10 +31,6 @@ return array(
             ),
             'folders' => array(
                 'location' => 'query'
-            ),
-            'user' => array(
-                'location' => 'query',
-                'required' => true
             )
         )
     ),


### PR DESCRIPTION
As per #58 getHappinessReport service definition has a user parameter but it does not appear to be a valid parameter for the [happiness report api call](https://developer.helpscout.com/help-desk-api/reports/happiness/happiness/) so I removed it. Would have liked to add a test for this but there does not seem to be any tests around the service definition stuff and I wouldn't know where to start.