### PR TITLE
Add endpoint for Conversations: Received Messages

### DIFF
--- a/src/HelpScout/descriptions/reports/conversations.php
+++ b/src/HelpScout/descriptions/reports/conversations.php
@@ -208,7 +208,7 @@ return array(
 
     'getConversationsReceivedMessagesReport' => array(
         'httpMethod' => 'GET',
-        'uri' => 'reports/conversations/new-drilldown.json',
+        'uri' => 'reports/conversations/received-messages.json',
         'parameters' => array(
             'start' => array(
                 'location' => 'query',

--- a/src/HelpScout/descriptions/reports/conversations.php
+++ b/src/HelpScout/descriptions/reports/conversations.php
@@ -203,6 +203,43 @@ return array(
                 'location' => 'query'
             )
         )
+    ),
+
+
+    'getConversationsReceivedMessagesReport' => array(
+        'httpMethod' => 'GET',
+        'uri' => 'reports/conversations/new-drilldown.json',
+        'parameters' => array(
+            'start' => array(
+                'location' => 'query',
+                'required' => true
+            ),
+            'end' => array(
+                'location' => 'query',
+                'required' => true
+            ),
+            'previousStart' => array(
+                'location' => 'query'
+            ),
+            'previousEnd' => array(
+                'location' => 'query'
+            ),
+            'mailboxes' => array(
+                'location' => 'query'
+            ),
+            'tags' => array(
+                'location' => 'query'
+            ),
+            'types' => array(
+                'location' => 'query'
+            ),
+            'folders' => array(
+                'location' => 'query'
+            ),
+            'viewBy' => array(
+                'location' => 'query'
+            )
+        )
     )
 
 );


### PR DESCRIPTION
This PR adds a service description for the [Conversations: Received Messages](https://developer.helpscout.com/help-desk-api/reports/conversations/received-messages/) endpoint in the Mailbox API v1.