### PR TITLE
Remove HTTPlug dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,6 @@
         "test:travis": ["@sniff", "@analyse", "@phpunit:clover"],
         "test:report": "vendor/bin/phpunit --coverage-html build/reports/phpunit"
     },
-    "suggest": {
-        "php-http/guzzle6-adapter": "Our preferred HTTP adapter"
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "psr/http-message": "^1.0",
-        "php-http/client-common": "^1.3",
         "ql/uri-template": "^1.1",
         "webmozart/assert": "^1.2",
         "guzzlehttp/guzzle": "^6.3",

--- a/src/Exception/RateLimitExceededException.php
+++ b/src/Exception/RateLimitExceededException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use Http\Client\Exception\HttpException;
+use GuzzleHttp\Exception\RequestException;
 
-class RateLimitExceededException extends HttpException implements Exception
+class RateLimitExceededException extends RequestException implements Exception
 {
 }

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use HelpScout\Api\Http\Hal\VndError;
 use GuzzleHttp\Exception\RequestException;
+use HelpScout\Api\Http\Hal\VndError;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace HelpScout\Api\Exception;
 
 use HelpScout\Api\Http\Hal\VndError;
-use Http\Client\Exception\HttpException;
+use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class ValidationErrorException extends HttpException implements Exception
+class ValidationErrorException extends RequestException implements Exception
 {
     /**
      * @var VndError


### PR DESCRIPTION
In #70 we removed HTTPlug in favour of using Guzzle but there were still a couple of dependencies left over. This PR removes those dependencies from `composer.json` and updates the code that was utilising them.