### PR TITLE
Add convenience methods and make setters fluent

### DIFF
--- a/src/Conversations/ChatConversation.php
+++ b/src/Conversations/ChatConversation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Conversations;
+
+class ChatConversation extends Conversation
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setType(static::TYPE_CHAT);
+    }
+}

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -26,6 +26,21 @@ class Conversation implements Extractable, Hydratable
         IncludesThreadDetails,
         HasCustomer;
 
+    public const TYPE_CHAT = 'chat';
+    public const TYPE_EMAIL = 'email';
+    public const TYPE_PHONE = 'phone';
+
+    public const STATUS_OPEN = 'open';
+    public const STATUS_ALL = 'all';
+    public const STATUS_CLOSED = 'closed';
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_SPAM = 'spam';
+
+    public const STATE_DELETED = 'deleted';
+    public const STATE_DRAFT = 'draft';
+    public const STATE_PUBLISHED = 'published';
+
     /**
      * @var int
      */
@@ -356,11 +371,13 @@ class Conversation implements Extractable, Hydratable
         return $this->id;
     }
 
-    public function setId(int $id)
+    public function setId(int $id): Conversation
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     public function getThreadCount(): ?int
@@ -368,9 +385,11 @@ class Conversation implements Extractable, Hydratable
         return $this->threadCount;
     }
 
-    public function setThreadCount(?int $threadCount)
+    public function setThreadCount(?int $threadCount): Conversation
     {
         $this->threadCount = $threadCount;
+
+        return $this;
     }
 
     public function isAutoReplyEnabled(): bool
@@ -378,9 +397,11 @@ class Conversation implements Extractable, Hydratable
         return $this->autoReplyEnabled;
     }
 
-    public function withAutoRepliesEnabled()
+    public function withAutoRepliesEnabled(): Conversation
     {
         $this->autoReplyEnabled = true;
+
+        return $this;
     }
 
     public function getNumber(): ?int
@@ -388,9 +409,11 @@ class Conversation implements Extractable, Hydratable
         return $this->number;
     }
 
-    public function setNumber(?int $number)
+    public function setNumber(?int $number): Conversation
     {
         $this->number = $number;
+
+        return $this;
     }
 
     public function getType(): ?string
@@ -398,14 +421,33 @@ class Conversation implements Extractable, Hydratable
         return $this->type;
     }
 
-    public function setType(?string $type)
+    public function setType(?string $type): Conversation
     {
         $this->type = $type;
+
+        return $this;
     }
 
-    public function setImported(bool $imported)
+    public function isChatConvo(): bool
+    {
+        return $this->getType() === self::TYPE_CHAT;
+    }
+
+    public function isEmailConvo(): bool
+    {
+        return $this->getType() === self::TYPE_EMAIL;
+    }
+
+    public function isPhoneConvo(): bool
+    {
+        return $this->getType() === self::TYPE_PHONE;
+    }
+
+    public function setImported(bool $imported): Conversation
     {
         $this->imported = $imported;
+
+        return $this;
     }
 
     public function isImported(): bool
@@ -418,9 +460,11 @@ class Conversation implements Extractable, Hydratable
         return $this->assignTo;
     }
 
-    public function setAssignTo(int $userId)
+    public function setAssignTo(int $userId): Conversation
     {
         $this->assignTo = $userId;
+
+        return $this;
     }
 
     public function getFolderId(): ?int
@@ -428,9 +472,11 @@ class Conversation implements Extractable, Hydratable
         return $this->folderId;
     }
 
-    public function setFolderId(?int $folderId)
+    public function setFolderId(?int $folderId): Conversation
     {
         $this->folderId = $folderId;
+
+        return $this;
     }
 
     public function getStatus(): ?string
@@ -438,9 +484,51 @@ class Conversation implements Extractable, Hydratable
         return $this->status;
     }
 
-    public function setStatus(?string $status)
+    public function setStatus(?string $status): Conversation
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function setClosed(): Conversation
+    {
+        return $this->setStatus(self::STATUS_CLOSED);
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->getStatus() === self::STATUS_CLOSED;
+    }
+
+    public function setSpam(): Conversation
+    {
+        return $this->setStatus(self::STATUS_SPAM);
+    }
+
+    public function isSpam(): bool
+    {
+        return $this->getStatus() === self::STATUS_SPAM;
+    }
+
+    public function setPending(): Conversation
+    {
+        return $this->setStatus(self::STATUS_PENDING);
+    }
+
+    public function isPending(): bool
+    {
+        return $this->getStatus() === self::STATUS_PENDING;
+    }
+
+    public function setActive(): Conversation
+    {
+        return $this->setStatus(self::STATUS_ACTIVE);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->getStatus() === self::STATUS_ACTIVE;
     }
 
     public function getState(): ?string
@@ -448,9 +536,41 @@ class Conversation implements Extractable, Hydratable
         return $this->state;
     }
 
-    public function setState(?string $state)
+    public function setState(?string $state): Conversation
     {
         $this->state = $state;
+
+        return $this;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->getState() === self::STATE_PUBLISHED;
+    }
+
+    public function publish(): Conversation
+    {
+        return $this->setState(self::STATE_PUBLISHED);
+    }
+
+    public function makeDraft(): Conversation
+    {
+        return $this->setState(self::STATE_DRAFT);
+    }
+
+    public function delete(): Conversation
+    {
+        return $this->setState(self::STATE_DELETED);
+    }
+
+    public function isDraft(): bool
+    {
+        return $this->getState() === self::STATE_DRAFT;
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->getState() === self::STATE_DELETED;
     }
 
     public function getSubject(): ?string
@@ -458,9 +578,11 @@ class Conversation implements Extractable, Hydratable
         return $this->subject;
     }
 
-    public function setSubject(?string $subject)
+    public function setSubject(?string $subject): Conversation
     {
         $this->subject = $subject;
+
+        return $this;
     }
 
     public function getPreview(): ?string
@@ -468,9 +590,11 @@ class Conversation implements Extractable, Hydratable
         return $this->preview;
     }
 
-    public function setPreview(?string $preview)
+    public function setPreview(?string $preview): Conversation
     {
         $this->preview = $preview;
+
+        return $this;
     }
 
     public function getMailboxId(): ?int
@@ -478,9 +602,11 @@ class Conversation implements Extractable, Hydratable
         return $this->mailboxId;
     }
 
-    public function setMailboxId(?int $mailboxId)
+    public function setMailboxId(?int $mailboxId): Conversation
     {
         $this->mailboxId = $mailboxId;
+
+        return $this;
     }
 
     public function getAssignee(): ?User
@@ -488,9 +614,21 @@ class Conversation implements Extractable, Hydratable
         return $this->assignee;
     }
 
-    public function setAssignee(?User $assignee)
+    public function isAssigned(): bool
+    {
+        return $this->getAssignee() !== null;
+    }
+
+    public function setAssignee(?User $assignee): Conversation
     {
         $this->assignee = $assignee;
+
+        return $this;
+    }
+
+    public function assignTo(?User $assignee): Conversation
+    {
+        return $this->setAssignee($assignee);
     }
 
     public function getCreatedAt(): ?DateTimeInterface
@@ -498,9 +636,11 @@ class Conversation implements Extractable, Hydratable
         return $this->createdAt;
     }
 
-    public function setCreatedAt(?DateTimeInterface $createdAt)
+    public function setCreatedAt(?DateTimeInterface $createdAt): Conversation
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     public function getClosedAt(): ?DateTimeInterface
@@ -508,9 +648,11 @@ class Conversation implements Extractable, Hydratable
         return $this->closedAt;
     }
 
-    public function setClosedAt(?DateTimeInterface $closedAt)
+    public function setClosedAt(?DateTimeInterface $closedAt): Conversation
     {
         $this->closedAt = $closedAt;
+
+        return $this;
     }
 
     public function getUserUpdatedAt(): ?DateTimeInterface
@@ -518,9 +660,11 @@ class Conversation implements Extractable, Hydratable
         return $this->userUpdatedAt;
     }
 
-    public function setUserUpdatedAt(?DateTimeInterface $userUpdatedAt)
+    public function setUserUpdatedAt(?DateTimeInterface $userUpdatedAt): Conversation
     {
         $this->userUpdatedAt = $userUpdatedAt;
+
+        return $this;
     }
 
     /**
@@ -531,9 +675,11 @@ class Conversation implements Extractable, Hydratable
         return $this->closedBy;
     }
 
-    public function setClosedBy(?User $closedBy)
+    public function setClosedBy(?User $closedBy): Conversation
     {
         $this->closedBy = $closedBy;
+
+        return $this;
     }
 
     public function getCustomerWaitingSince(): ?CustomerWaitingSince
@@ -541,9 +687,11 @@ class Conversation implements Extractable, Hydratable
         return $this->waitingSince;
     }
 
-    public function setCustomerWaitingSince(?CustomerWaitingSince $waitingSince)
+    public function setCustomerWaitingSince(?CustomerWaitingSince $waitingSince): Conversation
     {
         $this->waitingSince = $waitingSince;
+
+        return $this;
     }
 
     /**
@@ -554,9 +702,23 @@ class Conversation implements Extractable, Hydratable
         return $this->tags;
     }
 
-    public function setTags(Collection $tags)
+    /**
+     * @param Tag[]|Collection $tags
+     *
+     * @return Conversation
+     */
+    public function setTags(Collection $tags): Conversation
     {
         $this->tags = $tags;
+
+        return $this;
+    }
+
+    public function addTag(Tag $tag): Conversation
+    {
+        $this->getTags()->append($tag);
+
+        return $this;
     }
 
     /**
@@ -569,10 +731,21 @@ class Conversation implements Extractable, Hydratable
 
     /**
      * @param CustomField[]|Collection $customFields
+     *
+     * @return Conversation
      */
-    public function setCustomFields(Collection $customFields)
+    public function setCustomFields(Collection $customFields): Conversation
     {
         $this->customFields = $customFields;
+
+        return $this;
+    }
+
+    public function addCustomField(CustomField $customField): Conversation
+    {
+        $this->getCustomFields()->append($customField);
+
+        return $this;
     }
 
     /**
@@ -585,15 +758,28 @@ class Conversation implements Extractable, Hydratable
 
     /**
      * @param Thread[]|Collection $threads
+     *
+     * @return Conversation
      */
-    public function setThreads(Collection $threads)
+    public function setThreads(Collection $threads): Conversation
     {
         $this->threads = $threads;
+
+        return $this;
     }
 
-    public function setMailbox(Mailbox $mailbox)
+    public function addThread(Thread $thread): Conversation
+    {
+        $this->getThreads()->append($thread);
+
+        return $this;
+    }
+
+    public function setMailbox(Mailbox $mailbox): Conversation
     {
         $this->mailbox = $mailbox;
+
+        return $this;
     }
 
     public function getMailbox(): ?Mailbox

--- a/src/Conversations/EmailConversation.php
+++ b/src/Conversations/EmailConversation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Conversations;
+
+class EmailConversation extends Conversation
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setType(static::TYPE_EMAIL);
+    }
+}

--- a/src/Conversations/PhoneConversation.php
+++ b/src/Conversations/PhoneConversation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Conversations;
+
+class PhoneConversation extends Conversation
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setType(static::TYPE_PHONE);
+    }
+}

--- a/src/Conversations/Threads/Attachments/Attachment.php
+++ b/src/Conversations/Threads/Attachments/Attachment.php
@@ -101,11 +101,13 @@ class Attachment implements Extractable, Hydratable
         return $this->id;
     }
 
-    public function setId(int $id)
+    public function setId(int $id): Attachment
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     public function getFilename(): ?string
@@ -115,10 +117,14 @@ class Attachment implements Extractable, Hydratable
 
     /**
      * @param string|null $filename
+     *
+     * @return Attachment
      */
-    public function setFilename($filename)
+    public function setFilename($filename): Attachment
     {
         $this->filename = $filename;
+
+        return $this;
     }
 
     public function getMimeType(): ?string
@@ -128,10 +134,14 @@ class Attachment implements Extractable, Hydratable
 
     /**
      * @param string|null $mimeType
+     *
+     * @return Attachment
      */
-    public function setMimeType($mimeType)
+    public function setMimeType($mimeType): Attachment
     {
         $this->mimeType = $mimeType;
+
+        return $this;
     }
 
     public function getData(): ?string
@@ -141,10 +151,14 @@ class Attachment implements Extractable, Hydratable
 
     /**
      * @param string|null $data
+     *
+     * @return Attachment
      */
-    public function setData($data)
+    public function setData($data): Attachment
     {
         $this->data = $data;
+
+        return $this;
     }
 
     public function getWidth(): ?int
@@ -152,11 +166,13 @@ class Attachment implements Extractable, Hydratable
         return $this->width;
     }
 
-    public function setWidth(int $width)
+    public function setWidth(int $width): Attachment
     {
         Assert::greaterThan($width, 0);
 
         $this->width = $width;
+
+        return $this;
     }
 
     public function getHeight(): ?int
@@ -164,11 +180,13 @@ class Attachment implements Extractable, Hydratable
         return $this->height;
     }
 
-    public function setHeight(int $height)
+    public function setHeight(int $height): Attachment
     {
         Assert::greaterThan($height, 0);
 
         $this->height = $height;
+
+        return $this;
     }
 
     public function getSize(): ?int
@@ -176,10 +194,12 @@ class Attachment implements Extractable, Hydratable
         return $this->size;
     }
 
-    public function setSize(int $size)
+    public function setSize(int $size): Attachment
     {
         Assert::greaterThan($size, 0);
 
         $this->size = $size;
+
+        return $this;
     }
 }

--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -227,11 +227,13 @@ class Thread implements Extractable, Hydratable
         return $this->id;
     }
 
-    public function setId(int $id)
+    public function setId(int $id): Thread
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     public function getStatus(): ?string
@@ -246,7 +248,7 @@ class Thread implements Extractable, Hydratable
 
     public function wasCreatedByAction(): bool
     {
-        return is_string($this->actionText);
+        return \is_string($this->actionText);
     }
 
     public function getActionType(): ?string
@@ -264,9 +266,11 @@ class Thread implements Extractable, Hydratable
         return $this->text;
     }
 
-    public function setText(?string $text)
+    public function setText(?string $text): Thread
     {
         $this->text = $text;
+
+        return $this;
     }
 
     public function getAssignedTo(): ?array
@@ -289,9 +293,18 @@ class Thread implements Extractable, Hydratable
         return $this->openedAt;
     }
 
-    public function setAttachments(Collection $attachments)
+    public function setAttachments(Collection $attachments): Thread
     {
-        return $this->attachments = $attachments;
+        $this->attachments = $attachments;
+
+        return $this;
+    }
+
+    public function addAttachment(Attachment $attachment): Thread
+    {
+        $this->getAttachments()->append($attachment);
+
+        return $this;
     }
 
     public function getAttachments(): Collection
@@ -299,9 +312,11 @@ class Thread implements Extractable, Hydratable
         return $this->attachments;
     }
 
-    public function setImported(bool $imported)
+    public function setImported(bool $imported): Thread
     {
         $this->imported = $imported;
+
+        return $this;
     }
 
     public function isImported(): bool

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -186,220 +186,276 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param int $id
+     *
+     * @return Customer
      */
-    public function setId(int $id)
+    public function setId(int $id): Customer
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
      * @return DateTime|null
      */
-    public function getCreatedAt()
+    public function getCreatedAt(): ?DateTime
     {
         return $this->createdAt;
     }
 
     /**
      * @param DateTime|null $createdAt
+     *
+     * @return Customer
      */
-    public function setCreatedAt(DateTime $createdAt = null)
+    public function setCreatedAt(DateTime $createdAt = null): Customer
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
      * @return DateTime|null
      */
-    public function getUpdatedAt()
+    public function getUpdatedAt(): ?DateTime
     {
         return $this->updatedAt;
     }
 
     /**
      * @param DateTime|null $updatedAt
+     *
+     * @return Customer
      */
-    public function setUpdatedAt(DateTime $updatedAt = null)
+    public function setUpdatedAt(DateTime $updatedAt = null): Customer
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getFirstName()
+    public function getFirstName(): ?string
     {
         return $this->firstName;
     }
 
     /**
      * @param string|null $firstName
+     *
+     * @return Customer
      */
-    public function setFirstName($firstName)
+    public function setFirstName(?string $firstName): Customer
     {
         $this->firstName = $firstName;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getLastName()
+    public function getLastName(): ?string
     {
         return $this->lastName;
     }
 
     /**
      * @param string|null $lastName
+     *
+     * @return Customer
      */
-    public function setLastName($lastName)
+    public function setLastName(?string $lastName): Customer
     {
         $this->lastName = $lastName;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getGender()
+    public function getGender(): ?string
     {
         return $this->gender;
     }
 
     /**
      * @param string|null $gender
+     *
+     * @return Customer
      */
-    public function setGender($gender)
+    public function setGender(?string $gender): Customer
     {
         $this->gender = $gender;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getJobTitle()
+    public function getJobTitle(): ?string
     {
         return $this->jobTitle;
     }
 
     /**
      * @param string|null $jobTitle
+     *
+     * @return Customer
      */
-    public function setJobTitle($jobTitle)
+    public function setJobTitle(?string $jobTitle): Customer
     {
         $this->jobTitle = $jobTitle;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getLocation()
+    public function getLocation(): ?string
     {
         return $this->location;
     }
 
     /**
      * @param string|null $location
+     *
+     * @return Customer
      */
-    public function setLocation($location)
+    public function setLocation(?string $location): Customer
     {
         $this->location = $location;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getOrganization()
+    public function getOrganization(): ?string
     {
         return $this->organization;
     }
 
     /**
      * @param string|null $organization
+     *
+     * @return Customer
      */
-    public function setOrganization($organization)
+    public function setOrganization(?string $organization): Customer
     {
         $this->organization = $organization;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getPhotoType()
+    public function getPhotoType(): ?string
     {
         return $this->photoType;
     }
 
     /**
      * @param string|null $photoType
+     *
+     * @return Customer
      */
-    public function setPhotoType($photoType)
+    public function setPhotoType(?string $photoType): Customer
     {
         $this->photoType = $photoType;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getPhotoUrl()
+    public function getPhotoUrl(): ?string
     {
         return $this->photoUrl;
     }
 
     /**
      * @param string|null $photoUrl
+     *
+     * @return Customer
      */
-    public function setPhotoUrl($photoUrl)
+    public function setPhotoUrl(?string $photoUrl): Customer
     {
         $this->photoUrl = $photoUrl;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getBackground()
+    public function getBackground(): ?string
     {
         return $this->background;
     }
 
     /**
      * @param string|null $background
+     *
+     * @return Customer
      */
-    public function setBackground($background)
+    public function setBackground(?string $background): Customer
     {
         $this->background = $background;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getAge()
+    public function getAge(): ?string
     {
         return $this->age;
     }
 
     /**
      * @param string|null $age
+     *
+     * @return Customer
      */
-    public function setAge($age)
+    public function setAge(?string $age): Customer
     {
         $this->age = $age;
+
+        return $this;
     }
 
     /**
      * @return Address|null
      */
-    public function getAddress()
+    public function getAddress(): ?Address
     {
         return $this->address;
     }
 
     /**
      * @param Address|null $address
+     *
+     * @return Customer
      */
-    public function setAddress($address)
+    public function setAddress(?Address $address): Customer
     {
         $this->address = $address;
+
+        return $this;
     }
 
     /**
@@ -412,10 +468,21 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Chat[]|Collection $chats
+     *
+     * @return Customer
      */
-    public function setChats(Collection $chats)
+    public function setChats(Collection $chats): Customer
     {
         $this->chats = $chats;
+
+        return $this;
+    }
+
+    public function addChat(Chat $chat): Customer
+    {
+        $this->getChats()->append($chat);
+
+        return $this;
     }
 
     /**
@@ -428,10 +495,21 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Email[]|Collection $emails
+     *
+     * @return Customer
      */
-    public function setEmails(Collection $emails)
+    public function setEmails(Collection $emails): Customer
     {
         $this->emails = $emails;
+
+        return $this;
+    }
+
+    public function addEmail(Email $email): Customer
+    {
+        $this->getEmails()->append($email);
+
+        return $this;
     }
 
     /**
@@ -444,10 +522,21 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Phone[]|Collection $phones
+     *
+     * @return Customer
      */
-    public function setPhones(Collection $phones)
+    public function setPhones(Collection $phones): Customer
     {
         $this->phones = $phones;
+
+        return $this;
+    }
+
+    public function addPhone(Phone $phone): Customer
+    {
+        $this->getPhones()->append($phone);
+
+        return $this;
     }
 
     /**
@@ -460,10 +549,21 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param SocialProfile[]|Collection $socialProfiles
+     *
+     * @return Customer
      */
-    public function setSocialProfiles(Collection $socialProfiles)
+    public function setSocialProfiles(Collection $socialProfiles): Customer
     {
         $this->socialProfiles = $socialProfiles;
+
+        return $this;
+    }
+
+    public function addSocialProfile(SocialProfile $profile): Customer
+    {
+        $this->getSocialProfiles()->append($profile);
+
+        return $this;
     }
 
     /**
@@ -476,9 +576,20 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Website[]|Collection $websites
+     *
+     * @return Customer
      */
-    public function setWebsites(Collection $websites)
+    public function setWebsites(Collection $websites): Customer
     {
         $this->websites = $websites;
+
+        return $this;
+    }
+
+    public function addWebsite(Website $website): Customer
+    {
+        $this->getWebsites()->append($website);
+
+        return $this;
     }
 }

--- a/src/Customers/Entry/Address.php
+++ b/src/Customers/Entry/Address.php
@@ -60,17 +60,21 @@ class Address implements Extractable, Hydratable
     /**
      * @return string|null
      */
-    public function getCity()
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
     /**
      * @param string|null $city
+     *
+     * @return Address
      */
-    public function setCity($city)
+    public function setCity($city): Address
     {
         $this->city = $city;
+
+        return $this;
     }
 
     /**
@@ -83,57 +87,73 @@ class Address implements Extractable, Hydratable
 
     /**
      * @param array $lines
+     *
+     * @return Address
      */
-    public function setLines(array $lines)
+    public function setLines(array $lines): Address
     {
         $this->lines = $lines;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getState()
+    public function getState(): ?string
     {
         return $this->state;
     }
 
     /**
      * @param string|null $state
+     *
+     * @return Address
      */
-    public function setState($state)
+    public function setState($state): Address
     {
         $this->state = $state;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getPostalCode()
+    public function getPostalCode(): ?string
     {
         return $this->postalCode;
     }
 
     /**
      * @param string|null $postalCode
+     *
+     * @return Address
      */
-    public function setPostalCode($postalCode)
+    public function setPostalCode($postalCode): Address
     {
         $this->postalCode = $postalCode;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getCountry()
+    public function getCountry(): ?string
     {
         return $this->country;
     }
 
     /**
      * @param string|null $country
+     *
+     * @return Address
      */
-    public function setCountry($country)
+    public function setCountry($country): Address
     {
         $this->country = $country;
+
+        return $this;
     }
 }

--- a/src/Customers/Entry/Chat.php
+++ b/src/Customers/Entry/Chat.php
@@ -49,50 +49,62 @@ class Chat implements Extractable, Hydratable
     /**
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * @param int $id
+     *
+     * @return Chat
      */
-    public function setId(int $id)
+    public function setId(int $id): Chat
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getValue()
+    public function getValue(): ?string
     {
         return $this->value;
     }
 
     /**
      * @param string|null $value
+     *
+     * @return Chat
      */
-    public function setValue($value)
+    public function setValue($value): Chat
     {
         $this->value = $value;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
 
     /**
      * @param string|null $type
+     *
+     * @return Chat
      */
-    public function setType($type)
+    public function setType($type): Chat
     {
         $this->type = $type;
+
+        return $this;
     }
 }

--- a/src/Customers/Entry/Email.php
+++ b/src/Customers/Entry/Email.php
@@ -49,50 +49,62 @@ class Email implements Extractable, Hydratable
     /**
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * @param int $id
+     *
+     * @return Email
      */
-    public function setId(int $id)
+    public function setId(int $id): Email
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getValue()
+    public function getValue(): ?string
     {
         return $this->value;
     }
 
     /**
      * @param string|null $value
+     *
+     * @return Email
      */
-    public function setValue($value)
+    public function setValue(?string $value): Email
     {
         $this->value = $value;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
 
     /**
      * @param string|null $type
+     *
+     * @return Email
      */
-    public function setType($type)
+    public function setType(?string $type): Email
     {
         $this->type = $type;
+
+        return $this;
     }
 }

--- a/src/Customers/Entry/Phone.php
+++ b/src/Customers/Entry/Phone.php
@@ -49,50 +49,62 @@ class Phone implements Extractable, Hydratable
     /**
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * @param int $id
+     *
+     * @return Phone
      */
-    public function setId(int $id)
+    public function setId(int $id): Phone
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getValue()
+    public function getValue(): ?string
     {
         return $this->value;
     }
 
     /**
      * @param string|null $value
+     *
+     * @return Phone
      */
-    public function setValue($value)
+    public function setValue(?string $value): Phone
     {
         $this->value = $value;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
 
     /**
      * @param string|null $type
+     *
+     * @return Phone
      */
-    public function setType($type)
+    public function setType(?string $type): Phone
     {
         $this->type = $type;
+
+        return $this;
     }
 }

--- a/src/Customers/Entry/SocialProfile.php
+++ b/src/Customers/Entry/SocialProfile.php
@@ -49,50 +49,62 @@ class SocialProfile implements Extractable, Hydratable
     /**
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * @param int $id
+     *
+     * @return SocialProfile
      */
-    public function setId(int $id)
+    public function setId(int $id): SocialProfile
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getValue()
+    public function getValue(): ?string
     {
         return $this->value;
     }
 
     /**
      * @param string|null $value
+     *
+     * @return SocialProfile
      */
-    public function setValue($value)
+    public function setValue(?string $value): SocialProfile
     {
         $this->value = $value;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
 
     /**
      * @param string|null $type
+     *
+     * @return SocialProfile
      */
-    public function setType($type)
+    public function setType(?string $type): SocialProfile
     {
         $this->type = $type;
+
+        return $this;
     }
 }

--- a/src/Customers/Entry/Website.php
+++ b/src/Customers/Entry/Website.php
@@ -42,34 +42,42 @@ class Website implements Extractable, Hydratable
     /**
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * @param int $id
+     *
+     * @return Website
      */
-    public function setId(int $id)
+    public function setId(int $id): Website
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getValue()
+    public function getValue(): ?string
     {
         return $this->value;
     }
 
     /**
      * @param string|null $value
+     *
+     * @return Website
      */
-    public function setValue($value)
+    public function setValue($value): Website
     {
         $this->value = $value;
+
+        return $this;
     }
 }

--- a/src/Mailboxes/Entry/Field.php
+++ b/src/Mailboxes/Entry/Field.php
@@ -10,7 +10,7 @@ use HelpScout\Api\Entity\Hydratable;
 
 class Field implements Hydratable
 {
-    const TYPE_DROPDOWN = 'dropdown';
+    public const TYPE_DROPDOWN = 'dropdown';
 
     /**
      * @var int
@@ -74,28 +74,36 @@ class Field implements Hydratable
 
     /**
      * @param int $id
+     *
+     * @return Field
      */
-    public function setId(int $id)
+    public function setId(int $id): Field
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
-     * @return string
+     * @return ?string
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
     /**
      * @param string $name
+     *
+     * @return Field
      */
-    public function setName(string $name)
+    public function setName(string $name): Field
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -108,10 +116,14 @@ class Field implements Hydratable
 
     /**
      * @param string $type
+     *
+     * @return Field
      */
-    public function setType(string $type)
+    public function setType(string $type): Field
     {
         $this->type = $type;
+
+        return $this;
     }
 
     /**
@@ -124,10 +136,14 @@ class Field implements Hydratable
 
     /**
      * @param int $order
+     *
+     * @return Field
      */
-    public function setOrder(int $order)
+    public function setOrder(int $order): Field
     {
         $this->order = $order;
+
+        return $this;
     }
 
     /**
@@ -140,10 +156,14 @@ class Field implements Hydratable
 
     /**
      * @param bool $required
+     *
+     * @return Field
      */
-    public function setRequired(bool $required)
+    public function setRequired(bool $required): Field
     {
         $this->required = $required;
+
+        return $this;
     }
 
     /**
@@ -152,5 +172,19 @@ class Field implements Hydratable
     public function getOptions(): Collection
     {
         return $this->options;
+    }
+
+    public function setOptions(Collection $options): Field
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function addOption(FieldOption $option): Field
+    {
+        $this->getOptions()->append($option);
+
+        return $this;
     }
 }

--- a/src/Mailboxes/Entry/Folder.php
+++ b/src/Mailboxes/Entry/Folder.php
@@ -66,12 +66,16 @@ class Folder implements Hydratable
 
     /**
      * @param int $id
+     *
+     * @return Folder
      */
-    public function setId(int $id)
+    public function setId(int $id): Folder
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
@@ -84,10 +88,14 @@ class Folder implements Hydratable
 
     /**
      * @param string $name
+     *
+     * @return Folder
      */
-    public function setName(string $name)
+    public function setName(string $name): Folder
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -100,10 +108,14 @@ class Folder implements Hydratable
 
     /**
      * @param string $type
+     *
+     * @return Folder
      */
-    public function setType(string $type)
+    public function setType(string $type): Folder
     {
         $this->type = $type;
+
+        return $this;
     }
 
     /**
@@ -116,10 +128,14 @@ class Folder implements Hydratable
 
     /**
      * @param int $userId
+     *
+     * @return Folder
      */
-    public function setUserId(int $userId)
+    public function setUserId(int $userId): Folder
     {
         $this->userId = $userId;
+
+        return $this;
     }
 
     /**
@@ -132,10 +148,14 @@ class Folder implements Hydratable
 
     /**
      * @param int $totalCount
+     *
+     * @return Folder
      */
-    public function setTotalCount(int $totalCount)
+    public function setTotalCount(int $totalCount): Folder
     {
         $this->totalCount = $totalCount;
+
+        return $this;
     }
 
     /**
@@ -148,10 +168,14 @@ class Folder implements Hydratable
 
     /**
      * @param int $activeCount
+     *
+     * @return Folder
      */
-    public function setActiveCount(int $activeCount)
+    public function setActiveCount(int $activeCount): Folder
     {
         $this->activeCount = $activeCount;
+
+        return $this;
     }
 
     /**
@@ -164,9 +188,13 @@ class Folder implements Hydratable
 
     /**
      * @param DateTime $updatedAt
+     *
+     * @return Folder
      */
-    public function setUpdatedAt(DateTime $updatedAt)
+    public function setUpdatedAt(DateTime $updatedAt): Folder
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 }

--- a/src/Mailboxes/Mailbox.php
+++ b/src/Mailboxes/Mailbox.php
@@ -100,10 +100,14 @@ class Mailbox implements Hydratable
 
     /**
      * @param DateTime|null $createdAt
+     *
+     * @return Mailbox
      */
-    public function setCreatedAt(DateTime $createdAt = null)
+    public function setCreatedAt(DateTime $createdAt = null): Mailbox
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -116,10 +120,14 @@ class Mailbox implements Hydratable
 
     /**
      * @param DateTime|null $updatedAt
+     *
+     * @return Mailbox
      */
-    public function setUpdatedAt(DateTime $updatedAt = null)
+    public function setUpdatedAt(DateTime $updatedAt = null): Mailbox
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     /**
@@ -132,10 +140,14 @@ class Mailbox implements Hydratable
 
     /**
      * @param string $name
+     *
+     * @return Mailbox
      */
-    public function setName(string $name)
+    public function setName(string $name): Mailbox
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -148,10 +160,14 @@ class Mailbox implements Hydratable
 
     /**
      * @param string $slug
+     *
+     * @return Mailbox
      */
-    public function setSlug(string $slug)
+    public function setSlug(string $slug): Mailbox
     {
         $this->slug = $slug;
+
+        return $this;
     }
 
     /**
@@ -164,10 +180,14 @@ class Mailbox implements Hydratable
 
     /**
      * @param string $email
+     *
+     * @return Mailbox
      */
-    public function setEmail(string $email)
+    public function setEmail(string $email): Mailbox
     {
         $this->email = $email;
+
+        return $this;
     }
 
     /**
@@ -180,10 +200,21 @@ class Mailbox implements Hydratable
 
     /**
      * @param Field[]|Collection $fields
+     *
+     * @return Mailbox
      */
-    public function setFields(Collection $fields)
+    public function setFields(Collection $fields): Mailbox
     {
         $this->fields = $fields;
+
+        return $this;
+    }
+
+    public function addField(Field $field): Mailbox
+    {
+        $this->getFields()->append($field);
+
+        return $this;
     }
 
     /**
@@ -196,9 +227,20 @@ class Mailbox implements Hydratable
 
     /**
      * @param Folder[]|Collection $folders
+     *
+     * @return Mailbox
      */
-    public function setFolders(Collection $folders)
+    public function setFolders(Collection $folders): Mailbox
     {
         $this->folders = $folders;
+
+        return $this;
+    }
+
+    public function addFolder(Folder $folder): Mailbox
+    {
+        $this->getFolders()->append($folder);
+
+        return $this;
     }
 }

--- a/src/Tags/Tag.php
+++ b/src/Tags/Tag.php
@@ -112,18 +112,26 @@ class Tag implements Extractable, Hydratable
 
     /**
      * @param string|null $color
+     *
+     * @return Tag
      */
-    public function setColor($color)
+    public function setColor($color): Tag
     {
         $this->color = $color;
+
+        return $this;
     }
 
     /**
      * @param string|null $name
+     *
+     * @return Tag
      */
-    public function setName($name)
+    public function setName($name): Tag
     {
         $this->name = $name;
+
+        return $this;
     }
 
     public function getName(): ?string
@@ -133,10 +141,14 @@ class Tag implements Extractable, Hydratable
 
     /**
      * @param string|null $slug
+     *
+     * @return Tag
      */
-    public function setSlug($slug)
+    public function setSlug($slug): Tag
     {
         $this->slug = $slug;
+
+        return $this;
     }
 
     public function getSlug(): ?string
@@ -154,10 +166,14 @@ class Tag implements Extractable, Hydratable
 
     /**
      * @param null|string $createdAt
+     *
+     * @return Tag
      */
-    public function setCreatedAt($createdAt): void
+    public function setCreatedAt($createdAt): Tag
     {
         $this->createdAt = $this->transformDateTime($createdAt);
+
+        return $this;
     }
 
     /**
@@ -170,10 +186,14 @@ class Tag implements Extractable, Hydratable
 
     /**
      * @param null|string $updatedAt
+     *
+     * @return Tag
      */
-    public function setUpdatedAt($updatedAt): void
+    public function setUpdatedAt($updatedAt): Tag
     {
         $this->updatedAt = $this->transformDateTime($updatedAt);
+
+        return $this;
     }
 
     /**
@@ -186,9 +206,13 @@ class Tag implements Extractable, Hydratable
 
     /**
      * @param int|null $ticketCount
+     *
+     * @return Tag
      */
-    public function setTicketCount(?int $ticketCount): void
+    public function setTicketCount(?int $ticketCount): Tag
     {
         $this->ticketCount = $ticketCount;
+
+        return $this;
     }
 }

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -86,156 +86,196 @@ class User implements Hydratable
     }
 
     /**
-     * @param int $id
+     * @param null|int $id
+     *
+     * @return User
      */
-    public function setId(int $id)
+    public function setId(?int $id): User
     {
         Assert::greaterThan($id, 0);
 
         $this->id = $id;
+
+        return $this;
     }
 
     /**
      * @return DateTime|null
      */
-    public function getCreatedAt()
+    public function getCreatedAt(): ?DateTime
     {
         return $this->createdAt;
     }
 
     /**
      * @param DateTime|null $createdAt
+     *
+     * @return User
      */
-    public function setCreatedAt(DateTime $createdAt = null)
+    public function setCreatedAt(DateTime $createdAt = null): User
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
      * @return DateTime|null
      */
-    public function getUpdatedAt()
+    public function getUpdatedAt(): ?DateTime
     {
         return $this->updatedAt;
     }
 
     /**
      * @param DateTime|null $updatedAt
+     *
+     * @return User
      */
-    public function setUpdatedAt(DateTime $updatedAt = null)
+    public function setUpdatedAt(DateTime $updatedAt = null): User
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getFirstName()
+    public function getFirstName(): ?string
     {
         return $this->firstName;
     }
 
     /**
      * @param string|null $firstName
+     *
+     * @return User
      */
-    public function setFirstName($firstName)
+    public function setFirstName($firstName): User
     {
         $this->firstName = $firstName;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getLastName()
+    public function getLastName(): ?string
     {
         return $this->lastName;
     }
 
     /**
      * @param string|null $lastName
+     *
+     * @return User
      */
-    public function setLastName($lastName)
+    public function setLastName($lastName): User
     {
         $this->lastName = $lastName;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
     /**
      * @param string|null $email
+     *
+     * @return User
      */
-    public function setEmail($email)
+    public function setEmail($email): User
     {
         $this->email = $email;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getRole()
+    public function getRole(): ?string
     {
         return $this->role;
     }
 
     /**
      * @param string|null $role
+     *
+     * @return User
      */
-    public function setRole($role)
+    public function setRole($role): User
     {
         $this->role = $role;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getTimezone()
+    public function getTimezone(): ?string
     {
         return $this->timezone;
     }
 
     /**
      * @param string|null $timezone
+     *
+     * @return User
      */
-    public function setTimezone($timezone)
+    public function setTimezone($timezone): User
     {
         $this->timezone = $timezone;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getPhotoUrl()
+    public function getPhotoUrl(): ?string
     {
         return $this->photoUrl;
     }
 
     /**
      * @param string|null $photoUrl
+     *
+     * @return User
      */
-    public function setPhotoUrl($photoUrl)
+    public function setPhotoUrl($photoUrl): User
     {
         $this->photoUrl = $photoUrl;
+
+        return $this;
     }
 
     /**
      * @return string|null
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
 
     /**
      * @param string|null $type
+     *
+     * @return User
      */
-    public function setType($type)
+    public function setType($type): User
     {
         $this->type = $type;
+
+        return $this;
     }
 }

--- a/src/Webhooks/Webhook.php
+++ b/src/Webhooks/Webhook.php
@@ -95,10 +95,14 @@ class Webhook implements Hydratable, Extractable
 
     /**
      * @param int|null $id
+     *
+     * @return Webhook
      */
-    public function setId(?int $id): void
+    public function setId(?int $id): Webhook
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
@@ -111,14 +115,18 @@ class Webhook implements Hydratable, Extractable
 
     /**
      * @param string|null $state
+     *
+     * @return Webhook
      */
-    public function setState(?string $state): void
+    public function setState(?string $state): Webhook
     {
         if (null !== $state) {
             Assert::oneOf($state, self::VALID_STATES);
 
             $this->state = $state;
         }
+
+        return $this;
     }
 
     /**
@@ -131,8 +139,10 @@ class Webhook implements Hydratable, Extractable
 
     /**
      * @param array $events
+     *
+     * @return Webhook
      */
-    public function setEvents(array $events = []): void
+    public function setEvents(array $events = []): Webhook
     {
         $validEvents = array_values(
             array_intersect(self::VALID_EVENTS, $events)
@@ -141,6 +151,8 @@ class Webhook implements Hydratable, Extractable
         Assert::notEmpty($validEvents);
 
         $this->events = $validEvents;
+
+        return $this;
     }
 
     /**
@@ -153,10 +165,14 @@ class Webhook implements Hydratable, Extractable
 
     /**
      * @param string $url
+     *
+     * @return Webhook
      */
-    public function setUrl(?string $url): void
+    public function setUrl(?string $url): Webhook
     {
         $this->url = $url;
+
+        return $this;
     }
 
     /**
@@ -169,9 +185,13 @@ class Webhook implements Hydratable, Extractable
 
     /**
      * @param string $secret
+     *
+     * @return Webhook
      */
-    public function setSecret(?string $secret): void
+    public function setSecret(?string $secret): Webhook
     {
         $this->secret = $secret;
+
+        return $this;
     }
 }

--- a/src/Workflows/Workflow.php
+++ b/src/Workflows/Workflow.php
@@ -13,9 +13,11 @@ class Workflow implements Hydratable, Extractable
 {
     use HydratesData;
 
+    public const TYPE_MANUAL = 'manual';
+    public const TYPE_AUTOMATIC = 'automatic';
     public const VALID_TYPES = [
-        'manual',
-        'automatic',
+        self::TYPE_MANUAL,
+        self::TYPE_AUTOMATIC,
     ];
 
     /**
@@ -109,10 +111,14 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param int|null $id
+     *
+     * @return Workflow
      */
-    public function setId(?int $id): void
+    public function setId(?int $id): Workflow
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
@@ -125,10 +131,14 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param int|null $mailboxId
+     *
+     * @return Workflow
      */
-    public function setMailboxId(?int $mailboxId): void
+    public function setMailboxId(?int $mailboxId): Workflow
     {
         $this->mailboxId = $mailboxId;
+
+        return $this;
     }
 
     /**
@@ -141,13 +151,37 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param string|null $type
+     *
+     * @return Workflow
      */
-    public function setType(?string $type): void
+    public function setType(?string $type): Workflow
     {
         if ($type !== null) {
             Assert::oneOf($type, self::VALID_TYPES);
         }
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function isManual(): bool
+    {
+        return $this->getType() === self::TYPE_MANUAL;
+    }
+
+    public function isAutomatic(): bool
+    {
+        return $this->getType() === self::TYPE_AUTOMATIC;
+    }
+
+    public function setManual(): Workflow
+    {
+        return $this->setType(self::TYPE_MANUAL);
+    }
+
+    public function setAutomatic(): Workflow
+    {
+        return $this->setType(self::TYPE_AUTOMATIC);
     }
 
     /**
@@ -160,10 +194,14 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param string|null $status
+     *
+     * @return Workflow
      */
-    public function setStatus(?string $status): void
+    public function setStatus(?string $status): Workflow
     {
         $this->status = $status;
+
+        return $this;
     }
 
     /**
@@ -176,10 +214,14 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param int|null $order
+     *
+     * @return Workflow
      */
-    public function setOrder(?int $order): void
+    public function setOrder(?int $order): Workflow
     {
         $this->order = $order;
+
+        return $this;
     }
 
     /**
@@ -192,10 +234,14 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param string|null $name
+     *
+     * @return Workflow
      */
-    public function setName(?string $name): void
+    public function setName(?string $name): Workflow
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -208,10 +254,14 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param null|string $createdAt
+     *
+     * @return Workflow
      */
-    public function setCreatedAt($createdAt): void
+    public function setCreatedAt($createdAt): Workflow
     {
         $this->createdAt = $this->transformDateTime($createdAt);
+
+        return $this;
     }
 
     /**
@@ -224,9 +274,13 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param null|string $modifiedAt
+     *
+     * @return Workflow
      */
-    public function setModifiedAt($modifiedAt): void
+    public function setModifiedAt($modifiedAt): Workflow
     {
         $this->modifiedAt = $this->transformDateTime($modifiedAt);
+
+        return $this;
     }
 }

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -6,10 +6,14 @@ namespace HelpScout\Api\Tests\Conversations;
 
 use DateTime;
 use DateTimeInterface;
+use HelpScout\Api\Conversations\ChatConversation;
 use HelpScout\Api\Conversations\Conversation;
 use HelpScout\Api\Conversations\CustomerWaitingSince;
 use HelpScout\Api\Conversations\CustomField;
+use HelpScout\Api\Conversations\EmailConversation;
+use HelpScout\Api\Conversations\PhoneConversation;
 use HelpScout\Api\Conversations\Threads\ChatThread;
+use HelpScout\Api\Conversations\Threads\Thread;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Tags\Tag;
@@ -328,5 +332,79 @@ class ConversationTest extends TestCase
             'bcc' => [],
             'assignTo' => null,
         ], $conversation->extract());
+    }
+
+    public function testChatConvo()
+    {
+        $convo = new ChatConversation();
+        $this->assertSame(Conversation::TYPE_CHAT, $convo->getType());
+        $this->assertTrue($convo->isChatConvo());
+    }
+
+    public function testEmailConvo()
+    {
+        $convo = new EmailConversation();
+        $this->assertSame(Conversation::TYPE_EMAIL, $convo->getType());
+        $this->assertTrue($convo->isEmailConvo());
+    }
+
+    public function testPhoneConvo()
+    {
+        $convo = new PhoneConversation();
+        $this->assertSame(Conversation::TYPE_PHONE, $convo->getType());
+        $this->assertTrue($convo->isPhoneConvo());
+    }
+
+    public function testStatusMethods()
+    {
+        $convo = new Conversation();
+        $this->assertNull($convo->getStatus());
+
+        $convo->setActive();
+        $this->assertTrue($convo->isActive());
+
+        $convo->setPending();
+        $this->assertTrue($convo->isPending());
+
+        $convo->setSpam();
+        $this->assertTrue($convo->isSpam());
+
+        $convo->setClosed();
+        $this->assertTrue($convo->isClosed());
+
+        $this->assertNull($convo->getAssignee());
+        $this->assertFalse($convo->isAssigned());
+
+        $convo->assignTo(new User());
+        $this->assertTrue($convo->isAssigned());
+
+        $convo->publish();
+        $this->assertTrue($convo->isPublished());
+
+        $convo->makeDraft();
+        $this->assertTrue($convo->isDraft());
+
+        $convo->delete();
+        $this->assertTrue($convo->isDeleted());
+    }
+
+    public function testAddMethods()
+    {
+        $convo = new Conversation();
+
+        $tag = new Tag();
+        $this->assertEmpty($convo->getTags()->toArray());
+        $convo->addTag($tag);
+        $this->assertSame($tag, $convo->getTags()->toArray()[0]);
+
+        $field = new CustomField();
+        $this->assertEmpty($convo->getCustomFields()->toArray());
+        $convo->addCustomField($field);
+        $this->assertSame($field, $convo->getCustomFields()->toArray()[0]);
+
+        $thread = new Thread();
+        $this->assertEmpty($convo->getThreads()->toArray());
+        $convo->addThread($thread);
+        $this->assertSame($thread, $convo->getThreads()->toArray()[0]);
     }
 }

--- a/tests/Conversations/Threads/ThreadTest.php
+++ b/tests/Conversations/Threads/ThreadTest.php
@@ -6,6 +6,7 @@ namespace HelpScout\Api\Tests\Conversations\Threads;
 
 use DateTime;
 use DateTimeInterface;
+use HelpScout\Api\Conversations\Threads\Attachments\Attachment;
 use HelpScout\Api\Conversations\Threads\Thread;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Exception\RuntimeException;
@@ -286,5 +287,16 @@ class ThreadTest extends TestCase
         $this->expectExceptionMessage('Unrecognized thread type');
 
         Thread::resourceUrl(123);
+    }
+
+    public function testAddAttachment()
+    {
+        $thread = new Thread();
+
+        $this->assertEmpty($thread->getAttachments());
+
+        $attachment = new Attachment();
+        $thread->addAttachment($attachment);
+        $this->assertSame($attachment, $thread->getAttachments()->toArray()[0]);
     }
 }

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -6,6 +6,11 @@ namespace HelpScout\Api\Tests\Customers;
 
 use DateTime;
 use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Customers\Entry\Chat;
+use HelpScout\Api\Customers\Entry\Email;
+use HelpScout\Api\Customers\Entry\Phone;
+use HelpScout\Api\Customers\Entry\SocialProfile;
+use HelpScout\Api\Customers\Entry\Website;
 use PHPUnit\Framework\TestCase;
 
 class CustomerTest extends TestCase
@@ -125,5 +130,55 @@ class CustomerTest extends TestCase
             'background' => null,
             'age' => null,
         ], $customer->extract());
+    }
+
+    public function testAddChat()
+    {
+        $customer = new Customer();
+        $this->assertEmpty($customer->getChats());
+
+        $chat = new Chat();
+        $customer->addChat($chat);
+        $this->assertSame($chat, $customer->getChats()->toArray()[0]);
+    }
+
+    public function testAddEmail()
+    {
+        $customer = new Customer();
+        $this->assertEmpty($customer->getEmails());
+
+        $email = new Email();
+        $customer->addEmail($email);
+        $this->assertSame($email, $customer->getEmails()->toArray()[0]);
+    }
+
+    public function testAddPhone()
+    {
+        $customer = new Customer();
+        $this->assertEmpty($customer->getPhones());
+
+        $phone = new Phone();
+        $customer->addPhone($phone);
+        $this->assertSame($phone, $customer->getPhones()->toArray()[0]);
+    }
+
+    public function testAddSocialProfiles()
+    {
+        $customer = new Customer();
+        $this->assertEmpty($customer->getSocialProfiles());
+
+        $profile = new SocialProfile();
+        $customer->addSocialProfile($profile);
+        $this->assertSame($profile, $customer->getSocialProfiles()->toArray()[0]);
+    }
+
+    public function testAddWebsites()
+    {
+        $customer = new Customer();
+        $this->assertEmpty($customer->getWebsites());
+
+        $website = new Website();
+        $customer->addWebsite($website);
+        $this->assertSame($website, $customer->getWebsites()->toArray()[0]);
     }
 }

--- a/tests/Mailboxes/Entry/FieldTest.php
+++ b/tests/Mailboxes/Entry/FieldTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Mailboxes\Entry;
 
+use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Mailboxes\Entry\Field;
+use HelpScout\Api\Mailboxes\Entry\FieldOption;
 use PHPUnit\Framework\TestCase;
 
 class FieldTest extends TestCase
@@ -48,5 +50,19 @@ class FieldTest extends TestCase
         $this->assertSame(170, $options[1]->getId());
         $this->assertSame(2, $options[1]->getOrder());
         $this->assertSame('Stout', $options[1]->getLabel());
+    }
+
+    public function testMailboxFieldOptions()
+    {
+        $field = new Field();
+        $this->assertEmpty($field->getOptions());
+
+        $options = new Collection([new FieldOption()]);
+        $field->setOptions($options);
+        $this->assertCount(1, $field->getOptions());
+
+        $option = new FieldOption();
+        $field->addOption($option);
+        $this->assertSame($option, $field->getOptions()->toArray()[1]);
     }
 }

--- a/tests/Mailboxes/MailboxTest.php
+++ b/tests/Mailboxes/MailboxTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Mailboxes;
 
 use DateTime;
+use HelpScout\Api\Mailboxes\Entry\Field;
+use HelpScout\Api\Mailboxes\Entry\Folder;
 use HelpScout\Api\Mailboxes\Mailbox;
 use PHPUnit\Framework\TestCase;
 
@@ -58,5 +60,21 @@ class MailboxTest extends TestCase
         ]);
 
         $this->assertNull($mailbox->getUpdatedAt());
+    }
+
+    public function testAddMethods()
+    {
+        $mailbox = new Mailbox();
+
+        $this->assertEmpty($mailbox->getFields()->toArray());
+        $this->assertEmpty($mailbox->getFolders()->toArray());
+
+        $field = new Field();
+        $mailbox->addField($field);
+        $this->assertSame($field, $mailbox->getFields()->toArray()[0]);
+
+        $folder = new Folder();
+        $mailbox->addFolder($folder);
+        $this->assertSame($folder, $mailbox->getFolders()->toArray()[0]);
     }
 }

--- a/tests/Workflows/WorkflowTest.php
+++ b/tests/Workflows/WorkflowTest.php
@@ -24,7 +24,14 @@ class WorkflowTest extends TestCase
 
         $workflow = new Workflow();
         $workflow->hydrate($data);
+        $this->assertTrue($workflow->isManual());
 
         $this->assertSame($data, $workflow->extract());
+
+        $workflow->setAutomatic();
+        $this->assertTrue($workflow->isAutomatic());
+
+        $workflow->setManual();
+        $this->assertTrue($workflow->isManual());
     }
 }


### PR DESCRIPTION
This PR does a few things in an attempt to address issue #75:

1. Converts all setter methods to be fluent
2. Adds type-hints where they were previously missing
3. Adds constants and various convenience methods to prevent excessive `null` checks
4. Adds new conversation classes so we can do some easier type-hinting 

Making the setters fluent is a rather opinionated step, so I won't be surprised if some don't favor it. Let me know what you think. If you don't like that, then I can easily back that out and we can keep the rest.