### PR TITLE
Fix Object names for To/CC/BCC as pulled from API

### DIFF
--- a/src/HelpScout/model/thread/AbstractThread.php
+++ b/src/HelpScout/model/thread/AbstractThread.php
@@ -60,9 +60,9 @@ abstract class AbstractThread extends LineItem implements ConversationThread {
 		parent::__construct($data);
 		if ($data) {
 			$this->body    = isset($data->body)    ? $data->body    : null;
-			$this->toList  = isset($data->toList)  ? $data->toList  : null;
-			$this->ccList  = isset($data->ccList)  ? $data->ccList  : null;
-			$this->bccList = isset($data->bccList) ? $data->bccList : null;
+			$this->toList  = isset($data->to)      ? $data->to      : null;
+			$this->ccList  = isset($data->cc)      ? $data->cc      : null;
+			$this->bccList = isset($data->bcc)     ? $data->bcc     : null;
 			$this->state   = isset($data->state)   ? $data->state   : null;
 			$this->type    = isset($data->type)    ? $data->type    : null;
 			$this->openedAt= isset($data->openedAt)? $data->openedAt: null;


### PR DESCRIPTION
When creating a Thread (or any descendant) the AbstractThread base class was expect "toList", "ccList" and "bccList" items in the objects as pulled from the API. In practice, the "list" is just a construct within the API wrapper, and the fields in the API are called "to", "cc" and "bcc" respectively.

This commit fixes this oversight so the getCCList() function (and ToList/BCCList) work again.

Hoorah!