### PR TITLE
Updating example syntax for fetching users

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ When fetching a collection of entities the client will return an instance of `He
 
 ```php
 /** @var PagedCollection $users */
-$users = $client->getUsers();
+$users = $client->users()->list();
 
 // The current page number
 $users->getPageNumber();


### PR DESCRIPTION
This addresses outdated syntax that was brought to our attention via issue https://github.com/helpscout/helpscout-api-php/issues/93 by updating the syntax in this example to use the more fluent approach.