### PR TITLE
Hydrating all Customer entries, always

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,18 +172,6 @@ $filter = new (CustomerFilters)
 $customers = $client->customers()->list($filter);
 ```
 
-Get customers with pre-loaded sub-entities.
-
-```php
-use HelpScout\Api\Customers\CustomerRequest;
-
-$request = (new CustomerRequest)
-    ->withChats()
-    ->withEmails();
-
-$customers = $client->customers()->list($filter, $request);
-```
-
 Create a customer.
 
 ```php

--- a/examples/customers.php
+++ b/examples/customers.php
@@ -1,0 +1,29 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require '_credentials.php';
+
+use HelpScout\Api\ApiClientFactory;
+use HelpScout\Api\Customers\CustomerFilters;
+
+$client = ApiClientFactory::createClient();
+$client = $client->useClientCredentials($appId, $appSecret);
+
+// GET customers
+$customer = $client->customers()->get(161694345);
+
+// List customers
+$customers = $client->customers()
+    ->list()
+    ->getFirstPage()
+    ->toArray();
+
+$filters = (new CustomerFilters())
+    ->withFirstName('John')
+    ->withLastName('Smith')
+    ->withMailbox('12')
+    ->withModifiedSince(new DateTime('last month'))
+    ->withQuery('query')
+    ->withSortField('createdAt')
+    ->withSortOrder('asc');
+
+$customers = $client->customers()->list($filters);

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -155,6 +155,43 @@ class Customer implements Extractable, Hydratable
         $this->setPhotoUrl($data['photoUrl'] ?? null);
         $this->setBackground($data['background'] ?? null);
         $this->setAge($data['age'] ?? null);
+
+        if (isset($embedded['address']) && is_array($embedded['address'])) {
+            /** @var Address $address */
+            $address = $this->hydrateOne(Address::class, $embedded['address']);
+
+            $this->setAddress($address);
+        }
+
+        if (isset($embedded['chats']) && is_array($embedded['chats'])) {
+            $chats = $this->hydrateMany(Chat::class, $embedded['chats']);
+
+            $this->setChats($chats);
+        }
+
+        if (isset($embedded['emails']) && is_array($embedded['emails'])) {
+            $emails = $this->hydrateMany(Email::class, $embedded['emails']);
+
+            $this->setEmails($emails);
+        }
+
+        if (isset($embedded['social_profiles']) && is_array($embedded['social_profiles'])) {
+            $socialProfiles = $this->hydrateMany(SocialProfile::class, $embedded['social_profiles']);
+
+            $this->setSocialProfiles($socialProfiles);
+        }
+
+        if (isset($embedded['phones']) && is_array($embedded['phones'])) {
+            $phones = $this->hydrateMany(Phone::class, $embedded['phones']);
+
+            $this->setPhones($phones);
+        }
+
+        if (isset($embedded['websites']) && is_array($embedded['websites'])) {
+            $websites = $this->hydrateMany(Website::class, $embedded['websites']);
+
+            $this->setWebsites($websites);
+        }
     }
 
     /**
@@ -513,7 +550,6 @@ class Customer implements Extractable, Hydratable
      */
     public function setEmails(Collection $emails): Customer
     {
-        $emails =
         $this->emails = $emails;
 
         return $this;

--- a/src/Customers/CustomerRequest.php
+++ b/src/Customers/CustomerRequest.php
@@ -7,7 +7,9 @@ namespace HelpScout\Api\Customers;
 use HelpScout\Api\Assert\Assert;
 
 /**
- * This class is deprecated
+ * This class is deprecated now that all entities are always provided
+ *
+ * @see https://developer.helpscout.com/mailbox-api/changelog/#2019-01-25-new-return-all-customer-entries-always
  *
  * @deprecated
  */

--- a/src/Customers/CustomerRequest.php
+++ b/src/Customers/CustomerRequest.php
@@ -6,6 +6,11 @@ namespace HelpScout\Api\Customers;
 
 use HelpScout\Api\Assert\Assert;
 
+/**
+ * This class is deprecated
+ *
+ * @deprecated
+ */
 class CustomerRequest
 {
     /**

--- a/src/Customers/CustomerRequest.php
+++ b/src/Customers/CustomerRequest.php
@@ -7,11 +7,10 @@ namespace HelpScout\Api\Customers;
 use HelpScout\Api\Assert\Assert;
 
 /**
- * This class is deprecated now that all entities are always provided
- *
- * @see https://developer.helpscout.com/mailbox-api/changelog/#2019-01-25-new-return-all-customer-entries-always
+ * This class is deprecated now that all entities are always provided.
  *
  * @deprecated
+ * @see https://developer.helpscout.com/mailbox-api/changelog/#2019-01-25-new-return-all-customer-entries-always
  */
 class CustomerRequest
 {

--- a/src/Http/Hal/HalDeserializer.php
+++ b/src/Http/Hal/HalDeserializer.php
@@ -115,10 +115,15 @@ class HalDeserializer
         $resources = [];
         if (array_key_exists(self::EMBEDDED, $data)) {
             foreach ($data[self::EMBEDDED] as $rel => $resourceData) {
-                // TODO: Check if indexed (object or collection)
-                $resources[$rel] = array_map(function (array $data) {
-                    return self::createDocument($data);
-                }, $resourceData);
+                if (isset($resourceData[0]) && is_array($resourceData[0])) {
+                    $embeddedResource = array_map(function (array $data) {
+                        return self::createDocument($data);
+                    }, $resourceData);
+                } else {
+                    $embeddedResource = self::createDocument($resourceData);
+                }
+
+                $resources[$rel] = $embeddedResource;
             }
 
             unset($data[self::EMBEDDED]);

--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -58,7 +58,7 @@ class HalDocument
     {
         /** @var HalDocument $embeddedItemData */
         $embeddedData = [];
-        // Convert HalDocument[] to nested arrays
+        // Convert HalDocument|HalDocument[] to nested arrays
         foreach ($this->embedded as $embeddedType => $embeddedItems) {
             if (is_array($embeddedItems)) {
                 foreach ($embeddedItems as $embeddedItemData) {

--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -60,8 +60,12 @@ class HalDocument
         $embeddedData = [];
         // Convert HalDocument[] to nested arrays
         foreach ($this->embedded as $embeddedType => $embeddedItems) {
-            foreach ($embeddedItems as $embeddedItemData) {
-                $embeddedData[$embeddedType][] = $embeddedItemData->getData();
+            if (is_array($embeddedItems)) {
+                foreach ($embeddedItems as $embeddedItemData) {
+                    $embeddedData[$embeddedType][] = $embeddedItemData->getData();
+                }
+            } else {
+                $embeddedData[$embeddedType] = $embeddedItems->getData();
             }
         }
 

--- a/src/Support/HydratesData.php
+++ b/src/Support/HydratesData.php
@@ -5,9 +5,40 @@ declare(strict_types=1);
 namespace HelpScout\Api\Support;
 
 use DateTime;
+use HelpScout\Api\Entity\Collection;
+use HelpScout\Api\Entity\Hydratable;
 
 trait HydratesData
 {
+    /**
+     * Hydrates an individual instance of an entity.
+     */
+    private function hydrateOne(string $classPath, array $data): Hydratable
+    {
+        /** @var Hydratable $entity */
+        $entity = new $classPath();
+        $entity->hydrate($data);
+
+        return $entity;
+    }
+
+    /**
+     * Hydrates a collection of many entities.
+     */
+    private function hydrateMany(string $classPath, array $data): Collection
+    {
+        $collection = new Collection();
+        foreach ($data as $entityData) {
+            /** @var Hydratable $entity */
+            $entity = new $classPath();
+            $entity->hydrate($entityData);
+
+            $collection->append($entity);
+        }
+
+        return $collection;
+    }
+
     private function transformDateTime(?string $dateTime): ?DateTime
     {
         if ($dateTime === null) {

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -51,6 +51,157 @@ class CustomerTest extends TestCase
         $this->assertSame('52', $customer->getAge());
     }
 
+    public function testHydratesOneAddress()
+    {
+        $customer = new Customer();
+        $customer->hydrate([
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'updatedAt' => '2017-04-21T14:43:24Z',
+        ], [
+            'address' => [
+                'city' => 'Norfolk',
+            ],
+        ]);
+
+        // Only asserting one field here as the details of what's inflated are covered by the entity's tests
+        $this->assertSame('Norfolk', $customer->getAddress()->getCity());
+    }
+
+    public function testHydratesManyChats()
+    {
+        $customer = new Customer();
+        $customer->hydrate([
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'updatedAt' => '2017-04-21T14:43:24Z',
+        ], [
+            'chats' => [
+                [
+                    'id' => 123123,
+                ],
+                [
+                    'id' => 456223,
+                ],
+            ],
+        ]);
+
+        $chats = $customer->getChats();
+
+        // Only asserting one field here as the details of what's inflated are covered by the entity's tests
+        $this->assertInstanceOf(Chat::class, $chats[0]);
+        $this->assertSame(123123, $chats[0]->getId());
+
+        $this->assertInstanceOf(Chat::class, $chats[1]);
+        $this->assertSame(456223, $chats[1]->getId());
+    }
+
+    public function testHydratesManyEmails()
+    {
+        $customer = new Customer();
+        $customer->hydrate([
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'updatedAt' => '2017-04-21T14:43:24Z',
+        ], [
+            'emails' => [
+                [
+                    'id' => 689,
+                ],
+                [
+                    'id' => 798,
+                ],
+            ],
+        ]);
+
+        $emails = $customer->getEmails();
+
+        // Only asserting one field here as the details of what's inflated are covered by the entity's tests
+        $this->assertInstanceOf(Email::class, $emails[0]);
+        $this->assertSame(689, $emails[0]->getId());
+
+        $this->assertInstanceOf(Email::class, $emails[1]);
+        $this->assertSame(798, $emails[1]->getId());
+    }
+
+    public function testHydratesManySocialProfiles()
+    {
+        $customer = new Customer();
+        $customer->hydrate([
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'updatedAt' => '2017-04-21T14:43:24Z',
+        ], [
+            'social_profiles' => [
+                [
+                    'id' => 1233,
+                ],
+                [
+                    'id' => 4512,
+                ],
+            ],
+        ]);
+
+        $socialProfiles = $customer->getSocialProfiles();
+
+        // Only asserting one field here as the details of what's inflated are covered by the entity's tests
+        $this->assertInstanceOf(SocialProfile::class, $socialProfiles[0]);
+        $this->assertSame(1233, $socialProfiles[0]->getId());
+
+        $this->assertInstanceOf(SocialProfile::class, $socialProfiles[1]);
+        $this->assertSame(4512, $socialProfiles[1]->getId());
+    }
+
+    public function testHydratesManyPhones()
+    {
+        $customer = new Customer();
+        $customer->hydrate([
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'updatedAt' => '2017-04-21T14:43:24Z',
+        ], [
+            'phones' => [
+                [
+                    'id' => 9966,
+                ],
+                [
+                    'id' => 4433,
+                ],
+            ],
+        ]);
+
+        $phones = $customer->getPhones();
+
+        // Only asserting one field here as the details of what's inflated are covered by the entity's tests
+        $this->assertInstanceOf(Phone::class, $phones[0]);
+        $this->assertSame(9966, $phones[0]->getId());
+
+        $this->assertInstanceOf(Phone::class, $phones[1]);
+        $this->assertSame(4433, $phones[1]->getId());
+    }
+
+    public function testHydratesManyWebsites()
+    {
+        $customer = new Customer();
+        $customer->hydrate([
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'updatedAt' => '2017-04-21T14:43:24Z',
+        ], [
+            'websites' => [
+                [
+                    'id' => 1390,
+                ],
+                [
+                    'id' => 9530,
+                ],
+            ],
+        ]);
+
+        $websites = $customer->getWebsites();
+
+        // Only asserting one field here as the details of what's inflated are covered by the entity's tests
+        $this->assertInstanceOf(Website::class, $websites[0]);
+        $this->assertSame(1390, $websites[0]->getId());
+
+        $this->assertInstanceOf(Website::class, $websites[1]);
+        $this->assertSame(9530, $websites[1]->getId());
+    }
+
     public function testHydrateWithoutCreatedAt()
     {
         $customer = new Customer();

--- a/tests/Http/Hal/Entity/StubPayloads.php
+++ b/tests/Http/Hal/Entity/StubPayloads.php
@@ -11,6 +11,17 @@ class StubPayloads
         return json_encode(self::resource(1));
     }
 
+    public static function getResourceWithEmbeddedEntity(): string
+    {
+        $resource = self::resource(1);
+
+        $resource['_embedded']['address'] = [
+            'city' => 'Frankfurt',
+        ];
+
+        return json_encode($resource);
+    }
+
     public static function getInvalidResource(): string
     {
         $resource = self::resource(1);

--- a/tests/Http/Hal/HalDeserializerTest.php
+++ b/tests/Http/Hal/HalDeserializerTest.php
@@ -30,6 +30,14 @@ class HalDeserializerTest extends TestCase
         $this->assertCount(5, $halDocument->getEmbedded('entities'));
     }
 
+    public function testDeserializeDocumentWithCollectionWithEmbeddedEntity()
+    {
+        $halDocument = HalDeserializer::deserializeDocument(StubPayloads::getResourceWithEmbeddedEntity());
+
+        $this->assertInstanceOf(HalDocument::class, $halDocument);
+        $this->assertTrue($halDocument->hasEmbedded('address'));
+    }
+
     public function testDeserializeDocumentWithEmptyCollection()
     {
         $halDocument = HalDeserializer::deserializeDocument(StubPayloads::getResources(0));

--- a/tests/Http/Hal/HalDocumentTest.php
+++ b/tests/Http/Hal/HalDocumentTest.php
@@ -27,20 +27,33 @@ class HalDocumentTest extends TestCase
             $emptyLinks,
             [
                 'attachments' => [
-                    new HalDocument([
+                    new HalDocument(
+                        [
                             'id' => 4823,
                         ],
                         $emptyLinks,
                         []
                     ),
                 ],
+                'address' => new HalDocument(
+                    [
+                        'city' => 'London',
+                    ],
+                    $emptyLinks,
+                    []
+                ),
             ]
         );
 
         $entities = $thread->getEmbeddedEntities();
 
+        // Asserts that a HasMany collection of embedded entities is mapped correctly
         $this->assertArrayHasKey('attachments', $entities);
         $this->assertEquals(4823, $entities['attachments'][0]['id']);
+
+        // Asserts that a HasOne embedded entity is mapped correctly
+        $this->assertArrayHasKey('address', $entities);
+        $this->assertEquals('London', $entities['address']['city']);
     }
 
     public function testGetEmbedKeysIsAlwaysAnArray()

--- a/tests/Support/HydratesDataTest.php
+++ b/tests/Support/HydratesDataTest.php
@@ -5,12 +5,45 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Support;
 
 use DateTime;
+use HelpScout\Api\Customers\Entry\Address;
+use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Support\HydratesData;
 use PHPUnit\Framework\TestCase;
 
 class HydratesDataTest extends TestCase
 {
     use HydratesData;
+
+    public function testHydratesOneToEntity()
+    {
+        /** @var Address $address */
+        $address = $this->hydrateOne(Address::class, [
+            'city' => 'Baltimore',
+        ]);
+
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertEquals('Baltimore', $address->getCity());
+    }
+
+    public function testHydratesManyToCollection()
+    {
+        /** @var Address[]|Collection $address */
+        $addresses = $this->hydrateMany(Address::class, [
+            [
+                'city' => 'London',
+            ],
+            [
+                'city' => 'Baltimore',
+            ],
+        ]);
+        $this->assertInstanceOf(Collection::class, $addresses);
+
+        $this->assertInstanceOf(Address::class, $addresses[0]);
+        $this->assertEquals('London', $addresses[0]->getCity());
+
+        $this->assertInstanceOf(Address::class, $addresses[1]);
+        $this->assertEquals('Baltimore', $addresses[1]->getCity());
+    }
 
     public function testTransformsDateTimeToNullWhenNull()
     {


### PR DESCRIPTION
Change log:

 * `CustomerRequest` is deprecated, now that `customers()->get()` and `customers()->list()` [will always provide embedded entities](https://developer.helpscout.com/mailbox-api/changelog/#2019-01-25-new-return-all-customer-entries-always) (Thanks @bob983 for that).  It is deprecated and not removed to avoid breaking changes.  Any applications that still use this object to eager load will not experience any errors, it will just be more performant behind the scenes.
 * `HasOne` relationships (e.g. `Customer` has one `Address`) are now properly hydrated (see https://github.com/helpscout/helpscout-api-php/issues/89).  Fix involved addressing an `TODO` that was previously outstanding
 * Some usage examples have been added for `$client->customers()`

Once merged, this will become `2.0.4`.