### PR TITLE
Authorization code flow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ $client->setAccessToken('asdfasdf');
 ```
 The access token will always be used if available, regardless of whether you have other credentials set or not.
 
+### Authorization Code Flow
+
+Because the [authorization code](https://developer.helpscout.com/mailbox-api/overview/authentication/#authorization-code-flow) is only good for a single use, you'll need to exchange the code for and access token and refresh token prior to making additional api calls.  You'll also need to persist the tokens for reuse later.
+
+```php
+$client = ApiClientFactory::createClient();
+$client = $client->swapAuthorizationCodeForReusableTokens(
+    $appId,
+    $appSecret,
+    $authorizationCode
+);
+
+$credentials = $client->getAuthenticator()->getTokens();
+
+echo $credentials['access_token'].PHP_EOL;
+echo $credentials['refresh_token'].PHP_EOL;
+echo $credentials['expires_in'].PHP_EOL;
+```
+
 ### Customers
 
 Get a customer.  Whenever getting a customer, all it's entities (email addresses, phone numbers, social profiles, etc.) come preloaded in the same request.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ echo $credentials['refresh_token'].PHP_EOL;
 echo $credentials['expires_in'].PHP_EOL;
 ```
 
+In addition to providing the access/refresh tokens this will set the current auth to use those tokens, so you can freely make subsequent requests without reinitializing the client.
+
+```
+// uses the one-time authorization code for auth
+$client = $client->swapAuthorizationCodeForReusableTokens(
+    $appId,
+    $appSecret,
+    $authorizationCode
+);
+
+// uses access/refresh tokens for auth
+$client->users()->list();
+```
+
 ### Customers
 
 Get a customer.  Whenever getting a customer, all it's entities (email addresses, phone numbers, social profiles, etc.) come preloaded in the same request.

--- a/examples/auth.php
+++ b/examples/auth.php
@@ -1,0 +1,24 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require '_credentials.php';
+
+use HelpScout\Api\ApiClientFactory;
+
+
+// See https://developer.helpscout.com/mailbox-api/overview/authentication/#authorization-code-flow
+$appId = '';
+$appSecret = '';
+$authorizationCode = '';
+
+$client = ApiClientFactory::createClient();
+$client = $client->swapAuthorizationCodeForReusableTokens(
+    $appId,
+    $appSecret,
+    $authorizationCode
+);
+
+var_dump($client->getAuthenticator()->getTokens());
+
+// Additional requests after exchanging the code use the access/refresh tokens
+$users = $client->users()->list();
+print_r($users->getFirstPage()->toArray());

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -9,6 +9,7 @@ use HelpScout\Api\Conversations\Threads\Attachments\AttachmentsEndpoint;
 use HelpScout\Api\Conversations\Threads\ThreadsEndpoint;
 use HelpScout\Api\Customers\CustomersEndpoint;
 use HelpScout\Api\Customers\Entry\CustomerEntryEndpoint;
+use HelpScout\Api\Http\Auth\CodeCredentials;
 use HelpScout\Api\Http\Authenticator;
 use HelpScout\Api\Http\RestClient;
 use HelpScout\Api\Mailboxes\MailboxesEndpoint;
@@ -156,16 +157,25 @@ class ApiClient
     }
 
     /**
+     * Takes an authorization code and exchanges it for an access/refresh token pair.
+     *
      * @param string $appId
      * @param string $appSecret
-     * @param string $code
+     * @param string $authorizationCode
      *
      * @return ApiClient
      */
-    public function useCodeToken(string $appId, string $appSecret, string $code): ApiClient
-    {
-        $this->getAuthenticator()
-            ->useCodeToken($appId, $appSecret, $code);
+    public function swapAuthorizationCodeForReusableTokens(
+        string $appId,
+        string $appSecret,
+        string $authorizationCode
+    ): ApiClient {
+        $authenticator = $this->getAuthenticator();
+
+        $authenticator->setAuth(new CodeCredentials($appId, $appSecret, $authorizationCode));
+        $authenticator->fetchAccessAndRefreshToken();
+
+        $this->useRefreshToken($appId, $appSecret, $authenticator->refreshToken());
 
         return $this;
     }

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -156,6 +156,21 @@ class ApiClient
     }
 
     /**
+     * @param string $appId
+     * @param string $appSecret
+     * @param string $code
+     *
+     * @return ApiClient
+     */
+    public function useCodeToken(string $appId, string $appSecret, string $code): ApiClient
+    {
+        $this->getAuthenticator()
+            ->useCodeToken($appId, $appSecret, $code);
+
+        return $this;
+    }
+
+    /**
      * @param string $reportName
      * @param array  $params
      *

--- a/src/Http/Auth/CodeCredentials.php
+++ b/src/Http/Auth/CodeCredentials.php
@@ -79,4 +79,3 @@ class CodeCredentials implements Auth
         ];
     }
 }
-

--- a/src/Http/Auth/CodeCredentials.php
+++ b/src/Http/Auth/CodeCredentials.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Http\Auth;
+
+class CodeCredentials implements Auth
+{
+    public const TYPE = 'authorization_code';
+
+    /**
+     * @var string
+     */
+    private $appId;
+
+    /**
+     * @var string
+     */
+    private $appSecret;
+
+    /**
+     * @var string
+     */
+    private $code;
+
+    /**
+     * CodeCredentials constructor.
+     *
+     * @param string $appId
+     * @param string $appSecret
+     * @param string $code
+     */
+    public function __construct(string $appId, string $appSecret, string $code)
+    {
+        $this->appId = $appId;
+        $this->appSecret = $appSecret;
+        $this->code = $code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAppId(): string
+    {
+        return $this->appId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAppSecret(): string
+    {
+        return $this->appSecret;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload(): array
+    {
+        return [
+            'grant_type' => $this->getType(),
+            'code' => $this->getCode(),
+            'client_id' => $this->getAppId(),
+            'client_secret' => $this->getAppSecret(),
+        ];
+    }
+}
+

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -7,7 +7,6 @@ namespace HelpScout\Api\Http;
 use GuzzleHttp\Client;
 use HelpScout\Api\Http\Auth\Auth;
 use HelpScout\Api\Http\Auth\ClientCredentials;
-use HelpScout\Api\Http\Auth\CodeCredentials;
 use HelpScout\Api\Http\Auth\LegacyCredentials;
 use HelpScout\Api\Http\Auth\NullCredentials;
 use HelpScout\Api\Http\Auth\RefreshCredentials;
@@ -79,6 +78,34 @@ class Authenticator
     }
 
     /**
+     * @return string
+     */
+    public function accessToken(): ?string
+    {
+        return $this->accessToken;
+    }
+
+    /**
+     * @param string $refreshToken
+     *
+     * @return Authenticator
+     */
+    public function setRefreshToken(string $refreshToken): Authenticator
+    {
+        $this->refreshToken = $refreshToken;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function refreshToken(): ?string
+    {
+        return $this->refreshToken;
+    }
+
+    /**
      * @param Client $client
      *
      * @return Authenticator
@@ -141,13 +168,11 @@ class Authenticator
     }
 
     /**
-     * @param string $appId
-     * @param string $appSecret
-     * @param string $code
+     * @param Auth $auth
      */
-    public function useCodeToken(string $appId, string $appSecret, string $code): void
+    public function setAuth(Auth $auth): void
     {
-        $this->auth = new CodeCredentials($appId, $appSecret, $code);
+        $this->auth = $auth;
     }
 
     protected function fetchTokens(): void
@@ -158,7 +183,6 @@ class Authenticator
                 break;
             case ClientCredentials::TYPE:
             case RefreshCredentials::TYPE:
-            case CodeCredentials::TYPE:
                 $this->fetchAccessAndRefreshToken();
                 break;
             default:

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -215,7 +215,7 @@ class Authenticator
     }
 
     /**
-     * @param array $payload
+     * @param array  $payload
      * @param string $url
      *
      * @return array

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -7,6 +7,7 @@ namespace HelpScout\Api\Http;
 use GuzzleHttp\Client;
 use HelpScout\Api\Http\Auth\Auth;
 use HelpScout\Api\Http\Auth\ClientCredentials;
+use HelpScout\Api\Http\Auth\CodeCredentials;
 use HelpScout\Api\Http\Auth\LegacyCredentials;
 use HelpScout\Api\Http\Auth\NullCredentials;
 use HelpScout\Api\Http\Auth\RefreshCredentials;
@@ -139,6 +140,16 @@ class Authenticator
         $this->auth = new RefreshCredentials($appId, $appSecret, $refreshToken);
     }
 
+    /**
+     * @param string $appId
+     * @param string $appSecret
+     * @param string $code
+     */
+    public function useCodeToken(string $appId, string $appSecret, string $code): void
+    {
+        $this->auth = new CodeCredentials($appId, $appSecret, $code);
+    }
+
     protected function fetchTokens(): void
     {
         switch ($this->auth->getType()) {
@@ -147,6 +158,7 @@ class Authenticator
                 break;
             case ClientCredentials::TYPE:
             case RefreshCredentials::TYPE:
+            case CodeCredentials::TYPE:
                 $this->fetchAccessAndRefreshToken();
                 break;
             default:
@@ -179,7 +191,7 @@ class Authenticator
     }
 
     /**
-     * @param array  $payload
+     * @param array $payload
      * @param string $url
      *
      * @return array

--- a/src/Http/RestClientBuilder.php
+++ b/src/Http/RestClientBuilder.php
@@ -16,6 +16,7 @@ use HelpScout\Api\Http\Auth\ClientCredentials;
 use HelpScout\Api\Http\Auth\LegacyCredentials;
 use HelpScout\Api\Http\Auth\NullCredentials;
 use HelpScout\Api\Http\Auth\RefreshCredentials;
+use HelpScout\Api\Http\Auth\CodeCredentials;
 use HelpScout\Api\Http\Handlers\ClientErrorHandler;
 use HelpScout\Api\Http\Handlers\RateLimitHandler;
 use HelpScout\Api\Http\Handlers\ValidationHandler;
@@ -94,6 +95,12 @@ class RestClientBuilder
                     $authConfig['appId'],
                     $authConfig['appSecret'],
                     $authConfig['refreshToken']
+                );
+            case CodeCredentials::TYPE:
+                return new CodeCredentials(
+                    $authConfig['appId'],
+                    $authConfig['appSecret'],
+                    $authConfig['code']
                 );
             default:
                 return new NullCredentials();

--- a/src/Http/RestClientBuilder.php
+++ b/src/Http/RestClientBuilder.php
@@ -16,7 +16,6 @@ use HelpScout\Api\Http\Auth\ClientCredentials;
 use HelpScout\Api\Http\Auth\LegacyCredentials;
 use HelpScout\Api\Http\Auth\NullCredentials;
 use HelpScout\Api\Http\Auth\RefreshCredentials;
-use HelpScout\Api\Http\Auth\CodeCredentials;
 use HelpScout\Api\Http\Handlers\ClientErrorHandler;
 use HelpScout\Api\Http\Handlers\RateLimitHandler;
 use HelpScout\Api\Http\Handlers\ValidationHandler;
@@ -95,12 +94,6 @@ class RestClientBuilder
                     $authConfig['appId'],
                     $authConfig['appSecret'],
                     $authConfig['refreshToken']
-                );
-            case CodeCredentials::TYPE:
-                return new CodeCredentials(
-                    $authConfig['appId'],
-                    $authConfig['appSecret'],
-                    $authConfig['code']
                 );
             default:
                 return new NullCredentials();

--- a/tests/Http/Auth/CodeCredentialsTest.php
+++ b/tests/Http/Auth/CodeCredentialsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace HelpScout\Api\Tests\Http;
+namespace HelpScout\Api\Tests\Http\Auth;
 
 use HelpScout\Api\Http\Auth\CodeCredentials;
 use PHPUnit\Framework\TestCase;
@@ -18,9 +18,9 @@ class CodeCredentialsTest extends TestCase
         $credentials = new CodeCredentials($appId, $appSecret, $code);
 
         $this->assertSame([
-            'grant_type'    => CodeCredentials::TYPE,
-            'code'          => $code,
-            'client_id'     => $appId,
+            'grant_type' => CodeCredentials::TYPE,
+            'code' => $code,
+            'client_id' => $appId,
             'client_secret' => $appSecret,
         ], $credentials->getPayload());
     }

--- a/tests/Http/Auth/CodeCredentialsTest.php
+++ b/tests/Http/Auth/CodeCredentialsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Http;
+
+use HelpScout\Api\Http\Auth\CodeCredentials;
+use PHPUnit\Framework\TestCase;
+
+class CodeCredentialsTest extends TestCase
+{
+    public function testBuildsPayload()
+    {
+        $appId = '123512362';
+        $appSecret = 's5df5634s';
+        $code = '58785656';
+
+        $credentials = new CodeCredentials($appId, $appSecret, $code);
+
+        $this->assertSame([
+            'grant_type'    => CodeCredentials::TYPE,
+            'code'          => $code,
+            'client_id'     => $appId,
+            'client_secret' => $appSecret,
+        ], $credentials->getPayload());
+    }
+}

--- a/tests/Http/AuthenticatorTest.php
+++ b/tests/Http/AuthenticatorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Http;
+
+use GuzzleHttp\Client;
+use HelpScout\Api\Http\Auth\Auth;
+use HelpScout\Api\Http\Authenticator;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticatorTest extends TestCase
+{
+    /** @var MockInterface */
+    public $client;
+
+    public function setUp()
+    {
+        $this->client = Mockery::mock(Client::class);
+    }
+
+    public function testSetsAndProvidesTokens()
+    {
+        $accessToken = '123512362';
+        $refreshToken = 's5df5634s';
+
+        $authenticator = new Authenticator($this->client);
+        $authenticator->setAccessToken($accessToken);
+        $authenticator->setRefreshToken($refreshToken);
+
+        $this->assertSame($accessToken, $authenticator->accessToken());
+        $this->assertSame($refreshToken, $authenticator->refreshToken());
+    }
+
+    public function testSetsAndProvidesCredentials()
+    {
+        $credentials = Mockery::mock(Auth::class);
+
+        $authenticator = new Authenticator($this->client);
+        $authenticator->setAuth($credentials);
+
+        $this->assertSame($credentials, $authenticator->getAuthCredentials());
+    }
+}


### PR DESCRIPTION
This PR fulfills https://github.com/helpscout/helpscout-api-php/issues/98 and expands on the initial implementation provided by @scr4bble in https://github.com/helpscout/helpscout-api-php/pull/107.  Functionality is now included allowing devs to easily exchange the authorization code for access/refresh tokens.

# Authorization Code Flow

 Because the [authorization code](https://developer.helpscout.com/mailbox-api/overview/authentication/#authorization-code-flow) is only good for a single use, you'll need to exchange the code for and access token and refresh token prior to making additional api calls.  You'll also need to persist the tokens for reuse later.

 ```php
$client = ApiClientFactory::createClient();
$client = $client->swapAuthorizationCodeForReusableTokens(
    $appId,
    $appSecret,
    $authorizationCode
);
 $credentials = $client->getAuthenticator()->getTokens();
 echo $credentials['access_token'].PHP_EOL;
echo $credentials['refresh_token'].PHP_EOL;
echo $credentials['expires_in'].PHP_EOL;
```