### PR TITLE
Add deprecation notices 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ $client->useLegacyToken($clientId, $apiKey);
 $client->useRefreshToken($appId, $appSecret, $refreshToken);
 ```
 
+**Note**
+The `legacy_credentials` auth method is provided for developer convenience while both v1 and v2 of the API are active. When v1 of the API sunsets on June 6th, 2019, this auth scheme will no longer be active. 
+
 You can also pass auth credentials when you create the client.
 
 ```php
@@ -85,7 +88,7 @@ $config = [
 ];
 $client = ApiClientFactory::createClient($config);
 
-// Using Legacy credentials
+// Using Legacy credentials - deprecated and will be removed on June 6, 2019
 $config = [
     'auth' => [
         'type' => 'legacy_credentials',

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -127,10 +127,17 @@ class ApiClient
     }
 
     /**
+     * The Legacy Token auth scheme is provided as a developer convenience
+     * while transitioning from v1 to v2 of the API. On June 6, 2019, we will
+     * sunset v1 of the API. At that time, this method will no longer function
+     * and we will remove it from the SDK.
+     *
      * @param string $clientId
      * @param string $apiKey
      *
      * @return ApiClient
+     *
+     * @deprecated
      */
     public function useLegacyToken(string $clientId, string $apiKey): ApiClient
     {

--- a/src/Http/Auth/LegacyCredentials.php
+++ b/src/Http/Auth/LegacyCredentials.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace HelpScout\Api\Http\Auth;
 
 /**
- * Class LegacyCredentials
- * @package HelpScout\Api\Http\Auth
+ * Class LegacyCredentials.
+ *
  * @deprecated
  */
 class LegacyCredentials implements Auth

--- a/src/Http/Auth/LegacyCredentials.php
+++ b/src/Http/Auth/LegacyCredentials.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Http\Auth;
 
+/**
+ * Class LegacyCredentials
+ * @package HelpScout\Api\Http\Auth
+ * @deprecated
+ */
 class LegacyCredentials implements Auth
 {
     public const TYPE = 'legacy_credentials';

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -121,6 +121,12 @@ class Authenticator
     }
 
     /**
+     * The Legacy Token auth scheme is provided as a developer convenience
+     * while transitioning from v1 to v2 of the API. On June 6, 2019, we will
+     * sunset v1 of the API. At that time, this method will no longer function
+     * and we will remove it from the SDK
+     *
+     * @deprecated
      * @param string $clientId
      * @param string $apiKey
      */

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -124,9 +124,10 @@ class Authenticator
      * The Legacy Token auth scheme is provided as a developer convenience
      * while transitioning from v1 to v2 of the API. On June 6, 2019, we will
      * sunset v1 of the API. At that time, this method will no longer function
-     * and we will remove it from the SDK
+     * and we will remove it from the SDK.
      *
      * @deprecated
+     *
      * @param string $clientId
      * @param string $apiKey
      */


### PR DESCRIPTION
When v1 of the API sunsets on June 6, 2019, the transition service and the `LegacyCredentials` auth method will no longer function and will be removed.

This PR doesn't alter functionality. I simply updates the readme to be clearer about the use of that auth scheme and deprecates a few methods.