### PR TITLE
Flagging the legacy token conversion method as deprecated

### DIFF
--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -210,10 +210,10 @@ class Authenticator
     }
 
     /**
-     * The Legacy Token auth scheme is provided as a developer convenience
-     * while transitioning from v1 to v2 of the API. On June 6, 2019, we will
-     * sunset v1 of the API. At that time, this method will no longer function
-     * and we will remove it from the SDK.
+     * This conversion helper is provided as a developer convenience while
+     * transitioning from v1 to v2 of the API. On June 6, 2019, we will sunset
+     * v1 of the API. At that time, this method will no longer function and we
+     * will remove it from the SDK.
      *
      * @deprecated
      */

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -209,6 +209,14 @@ class Authenticator
         $this->refreshToken = $tokens['refresh_token'] ?? null;
     }
 
+    /**
+     * The Legacy Token auth scheme is provided as a developer convenience
+     * while transitioning from v1 to v2 of the API. On June 6, 2019, we will
+     * sunset v1 of the API. At that time, this method will no longer function
+     * and we will remove it from the SDK.
+     *
+     * @deprecated
+     */
     public function convertLegacyToken(): void
     {
         $tokens = $this->requestAuthTokens(


### PR DESCRIPTION
We missed deprecating the conversion helper method.