### PR TITLE
Creating Customer with Conversation or Thread

### DIFF
--- a/examples/conversations.php
+++ b/examples/conversations.php
@@ -32,7 +32,7 @@ $filters = (new ConversationFilters())
     ->withSortField('createdAt')
     ->withSortOrder('asc')
     ->withQuery('query')
-    ->withCustomField(123, 'blue');
+    ->withCustomFieldById(123, 'blue');
 
 $conversations = $client->conversations()->list($filters);
 

--- a/examples/customers.php
+++ b/examples/customers.php
@@ -4,9 +4,21 @@ require '_credentials.php';
 
 use HelpScout\Api\ApiClientFactory;
 use HelpScout\Api\Customers\CustomerFilters;
+use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Customers\Entry\Email;
 
 $client = ApiClientFactory::createClient();
 $client = $client->useClientCredentials($appId, $appSecret);
+
+// Create Customer
+$customer = new Customer();
+$customer->setFirstName('John');
+$customer->setLastName('Smith');
+$customer->addEmail(new Email([
+    'email' => "my-customer@their-business.com",
+    'type' => 'work',
+]));
+$client->customers()->create($customer);
 
 // GET customers
 $customer = $client->customers()->get(161694345);

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -285,7 +285,7 @@ class Conversation implements Extractable, Hydratable
         }
 
         if ($this->hasCustomer()) {
-            $data['customer'] = $this->getCustomerDataForEntity();
+            $data['customer'] = $this->getCustomer()->extract();
         }
 
         $assignee = $this->getAssignee();

--- a/src/Conversations/Threads/ChatThread.php
+++ b/src/Conversations/Threads/ChatThread.php
@@ -32,7 +32,7 @@ class ChatThread extends Thread
         $data['type'] = self::TYPE;
 
         if ($this->hasCustomer()) {
-            $data['customer'] = $this->getCustomerDataForEntity();
+            $data['customer'] = $this->getCustomer()->extract();
         }
 
         return $data;

--- a/src/Conversations/Threads/CustomerThread.php
+++ b/src/Conversations/Threads/CustomerThread.php
@@ -34,7 +34,7 @@ class CustomerThread extends Thread
         $data['type'] = self::TYPE;
 
         if ($this->hasCustomer()) {
-            $data['customer'] = $this->getCustomerDataForEntity();
+            $data['customer'] = $this->getCustomer()->extract();
         }
 
         return $data;

--- a/src/Conversations/Threads/PhoneThread.php
+++ b/src/Conversations/Threads/PhoneThread.php
@@ -32,7 +32,7 @@ class PhoneThread extends Thread
         $data['type'] = self::TYPE;
 
         if ($this->hasCustomer()) {
-            $data['customer'] = $this->getCustomerDataForEntity();
+            $data['customer'] = $this->getCustomer()->extract();
         }
 
         return $data;

--- a/src/Conversations/Threads/ReplyThread.php
+++ b/src/Conversations/Threads/ReplyThread.php
@@ -57,7 +57,7 @@ class ReplyThread extends Thread
         $data['draft'] = $this->isDraft();
 
         if ($this->hasCustomer()) {
-            $data['customer'] = $this->getCustomerDataForEntity();
+            $data['customer'] = $this->getCustomer()->extract();
         }
 
         // When creating threads "user" is expected to be numeric rather

--- a/src/Conversations/Threads/Support/HasCustomer.php
+++ b/src/Conversations/Threads/Support/HasCustomer.php
@@ -45,15 +45,4 @@ trait HasCustomer
     {
         return $this->getCustomer() instanceof Customer;
     }
-
-    protected function getCustomerDataForEntity(): array
-    {
-        $customer = $this->getCustomer();
-        $customerData = [
-            'id' => $customer->getId(),
-            'email' => $customer->getFirstEmail(),
-        ];
-
-        return array_filter($customerData);
-    }
 }

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -199,7 +199,8 @@ class Customer implements Extractable, Hydratable
      */
     public function extract(): array
     {
-        return [
+        // ensure no empty values are included in the extraction for cleaner debugging
+        return array_filter([
             'id' => $this->getId(),
             'firstName' => $this->getFirstName(),
             'lastName' => $this->getLastName(),
@@ -212,7 +213,7 @@ class Customer implements Extractable, Hydratable
             'background' => $this->getBackground(),
             'age' => $this->getAge(),
             'email' => $this->getFirstEmail(),
-        ];
+        ]);
     }
 
     /**

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -200,6 +200,7 @@ class Customer implements Extractable, Hydratable
     public function extract(): array
     {
         return [
+            'id' => $this->getId(),
             'firstName' => $this->getFirstName(),
             'lastName' => $this->getLastName(),
             'gender' => $this->getGender(),
@@ -210,6 +211,7 @@ class Customer implements Extractable, Hydratable
             'photoUrl' => $this->getPhotoUrl(),
             'background' => $this->getBackground(),
             'age' => $this->getAge(),
+            'email' => $this->getFirstEmail(),
         ];
     }
 

--- a/tests/Customers/CustomerClientIntegrationTest.php
+++ b/tests/Customers/CustomerClientIntegrationTest.php
@@ -32,14 +32,6 @@ class CustomerClientIntegrationTest extends ApiClientIntegrationTestCase
             [
                 'firstName' => 'Big',
                 'lastName' => 'Bird',
-                'gender' => null,
-                'jobTitle' => null,
-                'location' => null,
-                'organization' => null,
-                'photoType' => null,
-                'photoUrl' => null,
-                'background' => null,
-                'age' => null,
             ]
         );
     }
@@ -59,16 +51,9 @@ class CustomerClientIntegrationTest extends ApiClientIntegrationTestCase
             'https://api.helpscout.net/v2/customers/12',
             'PUT',
             [
+                'id' => 12,
                 'firstName' => 'Big',
                 'lastName' => 'Bird',
-                'gender' => null,
-                'jobTitle' => null,
-                'location' => null,
-                'organization' => null,
-                'photoType' => null,
-                'photoUrl' => null,
-                'background' => null,
-                'age' => null,
             ]
         );
     }

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -252,6 +252,7 @@ class CustomerTest extends TestCase
         $customer->setAge('52');
 
         $this->assertSame([
+            'id' => 12,
             'firstName' => 'Big',
             'lastName' => 'Bird',
             'gender' => 'unknown',
@@ -262,6 +263,26 @@ class CustomerTest extends TestCase
             'photoUrl' => '',
             'background' => 'Big yellow bird',
             'age' => '52',
+            'email' => null,
+        ], $customer->extract());
+    }
+
+    /**
+     * Commonly in v2 of the API we see scenarios where if a "Customer" has an email or id it'll use the existing
+     * Customer associated with those, otherwise it'll create a new Customer.  When extracting a Customer it'll
+     * most likely be used for Creating something, so including email as a primary attribute this cleaner.
+     */
+    public function testExtractsEmailAsAttribute()
+    {
+        $customer = new Customer();
+
+        $email = new Email();
+        $email->setValue('tester@mysite.com');
+
+        $customer->addEmail($email);
+
+        $this->assertArraySubset([
+            'email' => 'tester@mysite.com',
         ], $customer->extract());
     }
 
@@ -270,6 +291,7 @@ class CustomerTest extends TestCase
         $customer = new Customer();
 
         $this->assertSame([
+            'id' => null,
             'firstName' => null,
             'lastName' => null,
             'gender' => null,
@@ -280,6 +302,7 @@ class CustomerTest extends TestCase
             'photoUrl' => null,
             'background' => null,
             'age' => null,
+            'email' => null,
         ], $customer->extract());
     }
 

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -247,7 +247,7 @@ class CustomerTest extends TestCase
         $customer->setLocation('US');
         $customer->setOrganization('Sesame Street');
         $customer->setPhotoType('unknown');
-        $customer->setPhotoUrl('');
+        $customer->setPhotoUrl('https://photos.me');
         $customer->setBackground('Big yellow bird');
         $customer->setAge('52');
 
@@ -260,10 +260,9 @@ class CustomerTest extends TestCase
             'location' => 'US',
             'organization' => 'Sesame Street',
             'photoType' => 'unknown',
-            'photoUrl' => '',
+            'photoUrl' => 'https://photos.me',
             'background' => 'Big yellow bird',
             'age' => '52',
-            'email' => null,
         ], $customer->extract());
     }
 
@@ -290,20 +289,7 @@ class CustomerTest extends TestCase
     {
         $customer = new Customer();
 
-        $this->assertSame([
-            'id' => null,
-            'firstName' => null,
-            'lastName' => null,
-            'gender' => null,
-            'jobTitle' => null,
-            'location' => null,
-            'organization' => null,
-            'photoType' => null,
-            'photoUrl' => null,
-            'background' => null,
-            'age' => null,
-            'email' => null,
-        ], $customer->extract());
+        $this->assertSame([], $customer->extract());
     }
 
     public function testAddChat()


### PR DESCRIPTION
Target SDK version: v2.1.1

Resolves #118 where creating a Thread or Conversation with a New customer would not successfully populate the newly created Customer with basic attributes such as their name.

This PR resolves that by including all base Customer attributes in the request to create a Thread or Conversation so that these values will be corrected populated for that Customer.