### PR TITLE
Validate webhooks for parity with v1 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,19 @@ Delete a webhook.
 $client->webhooks()->delete($webhookId);
 ```
 
+#### Processing an incoming webhook
+You can also use the SDK to easily process an incoming webhook. To do this, you'll need a request object that satisfies the PSR-7 `RequestInterface` and the secret key you used when setting up the webhook. Signature validation will happen when creating the new object, so no need to check if it is valid or not. If the signatures do not match, the constructor of the `IncomingWebhook` object will throw an `InvalidSignatureException` to let you know something is wrong.
+
+```php
+/** @var RequestInterface $request */
+$request = new Request(...);
+$secret = 'superSekretKey';
+
+$incoming = new IncomingWebhook($request, $secret);
+```
+
+Once you have the incoming webhook object, you can check the type of payload (customer, conversation, or test) as well as retrieve the data. If a customer or conversation, you can retrieve the model associated. Otherwise, you can get the payload as either an associative array or standard class object.
+
 ### Workflows
 
 Fetch a paginated list of all workflows.

--- a/examples/incoming_webhook.php
+++ b/examples/incoming_webhook.php
@@ -1,0 +1,24 @@
+<?php
+
+use GuzzleHttp\Psr7\Request;
+use HelpScout\Api\Webhooks\IncomingWebhook;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$body = json_encode(['id' => 123]);
+$secret = 'asdfasdf';
+$signature = '7S2+kN8bZsrdAEADJ+yYfWWsf/4=';
+
+$headers = [
+    'HTTP_X_HELPSCOUT_SIGNATURE' => $signature,
+    'HTTP_X_HELPSCOUT_EVENT' => 'convo.deleted',
+];
+
+$request = new Request('POST', 'www.blah.blah', $headers, $body);
+$webhook = new IncomingWebhook($request, $secret);
+
+$eventType = $webhook->getEventType();
+if ($eventType === 'convo.deleted') {
+    $obj = $webhook->getDataObject();
+    echo $obj->id;
+}

--- a/src/Exception/InvalidSignatureException.php
+++ b/src/Exception/InvalidSignatureException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Exception;
+
+class InvalidSignatureException extends RuntimeException
+{
+    public function __construct(string $expectedSignature, string $actualSignature = '')
+    {
+        $actual = $actualSignature === ''
+            ? 'No signature'
+            : $actualSignature;
+
+        $message = sprintf(
+            'Signature mismatch: Expected signature is %s. %s was provided.',
+            $expectedSignature,
+            $actual
+        );
+
+        parent::__construct($message, 0, null);
+    }
+}

--- a/src/Webhooks/IncomingWebhook.php
+++ b/src/Webhooks/IncomingWebhook.php
@@ -15,12 +15,12 @@ class IncomingWebhook
 {
     public const SIGNATURE_HEADERS = [
         'HTTP_X_HELPSCOUT_SIGNATURE',
-        'X_HELPSCOUT_SIGNATURE'
+        'X_HELPSCOUT_SIGNATURE',
     ];
 
     public const EVENT_HEADERS = [
         'HTTP_X_HELPSCOUT_EVENT',
-        'X_HELPSCOUT_EVENT'
+        'X_HELPSCOUT_EVENT',
     ];
 
     public const TEST_EVENT = 'helpscout.test';
@@ -39,13 +39,14 @@ class IncomingWebhook
 
     /**
      * IncomingWebhook constructor.
+     *
      * @param RequestInterface $request
-     * @param string $secret
+     * @param string           $secret
      */
     public function __construct(RequestInterface $request, string $secret)
     {
         $this->request = $request;
-        $this->secret  = $secret;
+        $this->secret = $secret;
 
         $this->validateSignature();
     }
@@ -56,7 +57,7 @@ class IncomingWebhook
     protected function validateSignature(): void
     {
         $signature = $this->generateSignature();
-        $header    = $this->findHeader(self::SIGNATURE_HEADERS);
+        $header = $this->findHeader(self::SIGNATURE_HEADERS);
 
         if ($signature !== $header) {
             throw new InvalidSignatureException($signature, $header);
@@ -82,6 +83,7 @@ class IncomingWebhook
 
     /**
      * @param array $headers
+     *
      * @return string
      */
     protected function findHeader(array $headers): string
@@ -92,7 +94,7 @@ class IncomingWebhook
                 $value = $this->request->getHeader($header);
                 $value = array_shift($value);
                 if ($value !== null) {
-                    $signature =  $value;
+                    $signature = $value;
                 }
             }
         }
@@ -126,6 +128,7 @@ class IncomingWebhook
 
     /**
      * @param string $eventType
+     *
      * @return bool
      */
     protected function isEventTypeOf(string $eventType): bool
@@ -174,6 +177,7 @@ class IncomingWebhook
 
     /**
      * @return Conversation
+     *
      * @throws JsonException
      */
     public function getConversation(): Conversation
@@ -190,6 +194,7 @@ class IncomingWebhook
 
     /**
      * @return Customer
+     *
      * @throws JsonException
      */
     public function getCustomer(): Customer

--- a/src/Webhooks/IncomingWebhook.php
+++ b/src/Webhooks/IncomingWebhook.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Webhooks;
+
+use HelpScout\Api\Conversations\Conversation;
+use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Exception\InvalidSignatureException;
+use HelpScout\Api\Exception\JsonException;
+use HelpScout\Api\Http\Hal\HalDeserializer;
+use Psr\Http\Message\RequestInterface;
+
+class IncomingWebhook
+{
+    public const SIGNATURE_HEADERS = [
+        'HTTP_X_HELPSCOUT_SIGNATURE',
+        'X_HELPSCOUT_SIGNATURE'
+    ];
+
+    public const EVENT_HEADERS = [
+        'HTTP_X_HELPSCOUT_EVENT',
+        'X_HELPSCOUT_EVENT'
+    ];
+
+    public const TEST_EVENT = 'helpscout.test';
+    public const CONVO_EVENT = 'convo';
+    public const CUSTOMER_EVENT = 'customer';
+
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @var string
+     */
+    private $secret;
+
+    /**
+     * IncomingWebhook constructor.
+     * @param RequestInterface $request
+     * @param string $secret
+     */
+    public function __construct(RequestInterface $request, string $secret)
+    {
+        $this->request = $request;
+        $this->secret  = $secret;
+
+        $this->validateSignature();
+    }
+
+    /**
+     * @throws InvalidSignatureException
+     */
+    protected function validateSignature(): void
+    {
+        $signature = $this->generateSignature();
+        $header    = $this->findHeader(self::SIGNATURE_HEADERS);
+
+        if ($signature !== $header) {
+            throw new InvalidSignatureException($signature, $header);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    protected function generateSignature(): string
+    {
+        $body = $this->getJson();
+
+        return base64_encode(
+            hash_hmac(
+                'sha1',
+                $body,
+                $this->secret,
+                true
+            )
+        );
+    }
+
+    /**
+     * @param array $headers
+     * @return string
+     */
+    protected function findHeader(array $headers): string
+    {
+        $signature = '';
+        foreach ($headers as $header) {
+            if ($this->request->hasHeader($header)) {
+                $value = $this->request->getHeader($header);
+                $value = array_shift($value);
+                if ($value !== null) {
+                    $signature =  $value;
+                }
+            }
+        }
+
+        return $signature;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTestEvent(): bool
+    {
+        return $this->findHeader(self::EVENT_HEADERS) === self::TEST_EVENT;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isConversationEvent(): bool
+    {
+        return $this->isEventTypeOf('convo');
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCustomerEvent(): bool
+    {
+        return $this->isEventTypeOf('customer');
+    }
+
+    /**
+     * @param string $eventType
+     * @return bool
+     */
+    protected function isEventTypeOf(string $eventType): bool
+    {
+        $header = $this->getEventType();
+
+        return strpos($header, $eventType) === 0;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEventType(): string
+    {
+        return $this->findHeader(self::EVENT_HEADERS);
+    }
+
+    /**
+     * @return array
+     */
+    public function getDataArray(): array
+    {
+        return \json_decode(
+            $this->getJson(),
+            true
+        );
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function getDataObject(): \stdClass
+    {
+        return \json_decode(
+            $this->getJson()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getJson(): string
+    {
+        return (string) $this->request->getBody();
+    }
+
+    /**
+     * @return Conversation
+     * @throws JsonException
+     */
+    public function getConversation(): Conversation
+    {
+        $body = $this->getJson();
+
+        $resource = HalDeserializer::deserializeResource(
+            Conversation::class,
+            HalDeserializer::deserializeDocument($body)
+        );
+
+        return $resource->getEntity();
+    }
+
+    /**
+     * @return Customer
+     * @throws JsonException
+     */
+    public function getCustomer(): Customer
+    {
+        $body = $this->getJson();
+
+        $resource = HalDeserializer::deserializeResource(
+            Customer::class,
+            HalDeserializer::deserializeDocument($body)
+        );
+
+        return $resource->getEntity();
+    }
+}

--- a/src/Webhooks/IncomingWebhook.php
+++ b/src/Webhooks/IncomingWebhook.php
@@ -95,6 +95,7 @@ class IncomingWebhook
                 $value = array_shift($value);
                 if ($value !== null) {
                     $signature = $value;
+                    continue;
                 }
             }
         }

--- a/tests/Exceptions/InvalidSignatureExceptionTest.php
+++ b/tests/Exceptions/InvalidSignatureExceptionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Exceptions;
+
+use HelpScout\Api\Exception\InvalidSignatureException;
+use PHPUnit\Framework\TestCase;
+
+class InvalidSignatureExceptionTest extends TestCase
+{
+    public function testExceptionMessageWithActualSignature()
+    {
+        $expectedSignature = '123asdf';
+        $actualSignature = 'fdasdfas';
+
+        $message = "Signature mismatch: Expected signature is {$expectedSignature}. {$actualSignature} was provided.";
+        $exception = new InvalidSignatureException($expectedSignature, $actualSignature);
+
+        $this->assertSame($message, $exception->getMessage());
+    }
+
+    public function testExceptionMessageWithoutActualSignature()
+    {
+        $expectedSignature = '123asdf';
+
+        $message = "Signature mismatch: Expected signature is {$expectedSignature}. No signature was provided.";
+        $exception = new InvalidSignatureException($expectedSignature);
+
+        $this->assertSame($message, $exception->getMessage());
+    }
+}

--- a/tests/Webhooks/IncomingWebhookTest.php
+++ b/tests/Webhooks/IncomingWebhookTest.php
@@ -118,8 +118,8 @@ class IncomingWebhookTest extends TestCase
         $secret = 'asdffdsa';
 
         $headers = [
-            'HTTP_X_HELPSCOUT_SIGNATURE' => 'asdfasdfasdfasdf',
-            'HTTP_X_HELPSCOUT_EVENT' => 'helpscout.test',
+            'X_HELPSCOUT_SIGNATURE' => 'asdfasdfasdfasdf',
+            'X_HELPSCOUT_EVENT' => 'helpscout.test',
         ];
 
         $webhook = new IncomingWebhook(

--- a/tests/Webhooks/IncomingWebhookTest.php
+++ b/tests/Webhooks/IncomingWebhookTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Webhooks;
+
+use GuzzleHttp\Psr7\Request;
+use HelpScout\Api\Conversations\Conversation;
+use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Exception\InvalidSignatureException;
+use HelpScout\Api\Tests\Payloads\ConversationPayloads;
+use HelpScout\Api\Tests\Payloads\CustomerPayloads;
+use HelpScout\Api\Webhooks\IncomingWebhook;
+use PHPUnit\Framework\TestCase;
+
+class IncomingWebhookTest extends TestCase
+{
+    protected function createRequest(array $headers = [], string $body)
+    {
+        return new Request('POST', 'www.blah.blah', $headers, $body);
+    }
+
+    protected function generateSignature(string $body, string $secret): string
+    {
+        return base64_encode(
+            hash_hmac(
+                'sha1',
+                $body,
+                $secret,
+                true
+            )
+        );
+    }
+
+    public function testCreateIncomingConvoWebhook()
+    {
+        $body = ConversationPayloads::getConversation(123);
+        $secret = 'asdffdsa';
+
+        $signature = $this->generateSignature($body, $secret);
+
+        $headers = [
+            'HTTP_X_HELPSCOUT_SIGNATURE' => $signature,
+            'HTTP_X_HELPSCOUT_EVENT' => 'convo',
+        ];
+
+        $webhook = new IncomingWebhook(
+            $this->createRequest($headers, $body),
+            $secret
+        );
+
+        $this->assertTrue($webhook->isConversationEvent());
+        $convo = $webhook->getConversation();
+        $this->assertInstanceOf(
+            Conversation::class,
+            $convo
+        );
+        $this->assertSame(123, $convo->getId());
+    }
+
+    public function testCreateIncomingCustomerWebhook()
+    {
+        $body = CustomerPayloads::getCustomer(123);
+        $secret = 'asdffdsa';
+
+        $signature = $this->generateSignature($body, $secret);
+
+        $headers = [
+            'HTTP_X_HELPSCOUT_SIGNATURE' => $signature,
+            'HTTP_X_HELPSCOUT_EVENT' => 'customer',
+        ];
+
+        $webhook = new IncomingWebhook(
+            $this->createRequest($headers, $body),
+            $secret
+        );
+
+        $this->assertTrue($webhook->isCustomerEvent());
+        $customer = $webhook->getCustomer();
+        $this->assertInstanceOf(
+            Customer::class,
+            $customer
+        );
+        $this->assertSame(123, $customer->getId());
+    }
+
+    public function testCreateIncomingWebhook()
+    {
+        $body = json_encode(['id' => 123]);
+        $secret = 'asdffdsa';
+
+        $signature = $this->generateSignature($body, $secret);
+
+        $headers = [
+            'HTTP_X_HELPSCOUT_SIGNATURE' => $signature,
+            'HTTP_X_HELPSCOUT_EVENT' => 'helpscout.test',
+        ];
+
+        $webhook = new IncomingWebhook(
+            $this->createRequest($headers, $body),
+            $secret
+        );
+
+        $this->assertTrue($webhook->isTestEvent());
+        $this->assertSame(
+            ['id' => 123],
+            $webhook->getDataArray()
+        );
+        $obj = $webhook->getDataObject();
+        $this->assertSame(123, $obj->id);
+    }
+
+    public function testCreateInvalidIncomingWebhook()
+    {
+        $this->expectException(InvalidSignatureException::class);
+
+        $body = json_encode(['id' => 123]);
+        $secret = 'asdffdsa';
+
+        $headers = [
+            'HTTP_X_HELPSCOUT_SIGNATURE' => 'asdfasdfasdfasdf',
+            'HTTP_X_HELPSCOUT_EVENT' => 'helpscout.test',
+        ];
+
+        $webhook = new IncomingWebhook(
+            $this->createRequest($headers, $body),
+            $secret
+        );
+    }
+}


### PR DESCRIPTION
This PR resolves #121 

Using the SDK, you can now validate incoming webhooks by passing a PSR-7 MessageInterface and the secret key used when creating the webhook. From there, the functionality is the same as with v1 of the SDK - you can determine if the webhook is a convo, customer, or test. If a convo or customer, you can retrieve the associated entity.

Future enhancements would be to add checks for all the possibly event types as well as to automatically hydrate the entity and sub-entities from the API rather than relying upon what is in the payload.