### PR TITLE
Refactor method names to reflect functionality for assigning convos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse src tests --level=5",
         "fix": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
-        "sniff": "vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run --stop-on-violation",
+        "sniff": "vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run --stop-on-violation --verbose",
         "phpunit": "vendor/bin/phpunit",
         "phpunit:clover": "vendor/bin/phpunit --coverage-clover build/logs/clover.xml",
         "test": ["@sniff", "@analyse", "@phpunit"],

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -453,12 +453,8 @@ class Conversation implements Extractable, Hydratable
     }
 
     /**
-     * Sets the assignTo Property.
-     * (Slated for deprecation in next verion release in favor of more descriptive method name setAssigneeId()).
-     *
-     * @param int $userId
-     *
-     * @return Conversation
+     * @deprecated
+     * @see setAssignee()
      */
     public function setAssignTo(int $userId): Conversation
     {

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -74,7 +74,7 @@ class Conversation implements Extractable, Hydratable
     /**
      * @var int|null
      */
-    private $assignTo;
+    private $assigneeId;
 
     /**
      * @var int
@@ -449,12 +449,12 @@ class Conversation implements Extractable, Hydratable
 
     public function getAssigneeId(): ?int
     {
-        return $this->assignTo;
+        return $this->assigneeId;
     }
 
     public function setAssigneeId(int $userId): Conversation
     {
-        $this->assignTo = $userId;
+        $this->assigneeId = $userId;
 
         return $this;
     }
@@ -615,7 +615,7 @@ class Conversation implements Extractable, Hydratable
     {
         $this->assignee = $assignee;
         $this->setAssigneeId($assignee->getId());
-        
+
         return $this;
     }
 

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -452,10 +452,6 @@ class Conversation implements Extractable, Hydratable
         return $this->assignTo;
     }
 
-    /**
-     * @deprecated
-     * @see setAssignee()
-     */
     public function setAssignTo(int $userId): Conversation
     {
         $this->assignTo = $userId;

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -257,7 +257,7 @@ class Conversation implements Extractable, Hydratable
             'threadCount' => $this->getThreadCount(),
             'autoReply' => $this->isAutoReplyEnabled(),
             'type' => $this->getType(),
-            'assignTo' => $this->getAssignTo(),
+            'assignTo' => $this->getAssigneeId(),
             'folderId' => $this->getFolderId(),
             'status' => $this->getStatus(),
             'state' => $this->getState(),
@@ -447,12 +447,12 @@ class Conversation implements Extractable, Hydratable
         return $this->imported;
     }
 
-    public function getAssignTo(): ?int
+    public function getAssigneeId(): ?int
     {
         return $this->assignTo;
     }
 
-    public function setAssignTo(int $userId): Conversation
+    public function setAssigneeId(int $userId): Conversation
     {
         $this->assignTo = $userId;
 
@@ -614,7 +614,8 @@ class Conversation implements Extractable, Hydratable
     public function setAssignee(?User $assignee): Conversation
     {
         $this->assignee = $assignee;
-
+        $this->setAssigneeId($assignee->getId());
+        
         return $this;
     }
 

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -74,7 +74,7 @@ class Conversation implements Extractable, Hydratable
     /**
      * @var int|null
      */
-    private $assigneeId;
+    private $assignTo;
 
     /**
      * @var int
@@ -257,7 +257,7 @@ class Conversation implements Extractable, Hydratable
             'threadCount' => $this->getThreadCount(),
             'autoReply' => $this->isAutoReplyEnabled(),
             'type' => $this->getType(),
-            'assignTo' => $this->getAssigneeId(),
+            'assignTo' => $this->getAssignTo(),
             'folderId' => $this->getFolderId(),
             'status' => $this->getStatus(),
             'state' => $this->getState(),
@@ -447,14 +447,21 @@ class Conversation implements Extractable, Hydratable
         return $this->imported;
     }
 
-    public function getAssigneeId(): ?int
+    public function getAssignTo(): ?int
     {
-        return $this->assigneeId;
+        return $this->assignTo;
     }
 
-    public function setAssigneeId(int $userId): Conversation
+    /**
+     * Sets the assignTo Property.
+     * (Slated for deprecation in next verion release in favor of more descriptive method name setAssigneeId())
+     *
+     * @param integer $userId
+     * @return Conversation
+     */
+    public function setAssignTo(int $userId): Conversation
     {
-        $this->assigneeId = $userId;
+        $this->assignTo = $userId;
 
         return $this;
     }
@@ -614,7 +621,7 @@ class Conversation implements Extractable, Hydratable
     public function setAssignee(?User $assignee): Conversation
     {
         $this->assignee = $assignee;
-        $this->setAssigneeId($assignee->getId());
+        $this->setAssignTo($assignee->getId());
 
         return $this;
     }

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -454,9 +454,10 @@ class Conversation implements Extractable, Hydratable
 
     /**
      * Sets the assignTo Property.
-     * (Slated for deprecation in next verion release in favor of more descriptive method name setAssigneeId())
+     * (Slated for deprecation in next verion release in favor of more descriptive method name setAssigneeId()).
      *
-     * @param integer $userId
+     * @param int $userId
+     *
      * @return Conversation
      */
     public function setAssignTo(int $userId): Conversation

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -346,7 +346,7 @@ class ConversationTest extends TestCase
         $assignee->setId(41);
         $convo->setAssignee($assignee);
 
-        $this->assertSame($user->getId(), $convo->getAssignTo());
+        $this->assertSame($assignee->getId(), $convo->getAssignTo());
     }
 
     public function testChatConvo()

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -163,11 +163,16 @@ class ConversationTest extends TestCase
 
     public function testExtract()
     {
+        $assignee = new User();
+        $assignee->setId(9865);
+        $assignee->setFirstName('Mr');
+        $assignee->setLastName('Robot');
+
         $conversation = new Conversation();
         $conversation->setId(12);
         $conversation->setNumber(3526);
         $conversation->setThreadCount(2);
-        $conversation->setAssignTo(2942);
+        $conversation->setAssigneeId($assignee->getId());
         $conversation->withAutoRepliesEnabled();
         $conversation->setType('email');
         $conversation->setImported(true);
@@ -205,11 +210,8 @@ class ConversationTest extends TestCase
         $customer->setEmails($emails);
         $conversation->setCustomer($customer);
 
-        $user = new User();
-        $user->setId(9865);
-        $user->setFirstName('Mr');
-        $user->setLastName('Robot');
-        $conversation->setAssignee($user);
+        
+        $conversation->setAssignee($assignee);
 
         $customField = new CustomField();
         $customField->setId(936);
@@ -239,7 +241,7 @@ class ConversationTest extends TestCase
             'threadCount' => 2,
             'autoReply' => true,
             'type' => 'email',
-            'assignTo' => 2942,
+            'assignTo' => 9865,
             'imported' => true,
             'folderId' => 132,
             'status' => 'closed',
@@ -376,7 +378,9 @@ class ConversationTest extends TestCase
         $this->assertNull($convo->getAssignee());
         $this->assertFalse($convo->isAssigned());
 
-        $convo->assignTo(new User());
+        $user = new User();
+        $user->setId(1);
+        $convo->assignTo($user);
         $this->assertTrue($convo->isAssigned());
 
         $convo->publish();

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -334,18 +334,18 @@ class ConversationTest extends TestCase
             'assignTo' => null,
         ], $conversation->extract());
     }
-    
+
     /**
-     * See https://github.com/helpscout/helpscout-api-php/issues/111
+     * See https://github.com/helpscout/helpscout-api-php/issues/111.
      */
     public function testSettingAssigneeAlsoSetsAssignToId()
     {
         $convo = new Conversation();
-        
+
         $assignee = new User();
         $assignee->setId(41);
         $convo->setAssignee($assignee);
-        
+
         $this->assertSame($user->getId(), $convo->getAssignTo());
     }
 

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -334,6 +334,20 @@ class ConversationTest extends TestCase
             'assignTo' => null,
         ], $conversation->extract());
     }
+    
+    /**
+     * See https://github.com/helpscout/helpscout-api-php/issues/111
+     */
+    public function testSettingAssigneeAlsoSetsAssignToId()
+    {
+        $convo = new Conversation();
+        
+        $assignee = new User();
+        $assignee->setId(41);
+        $convo->setAssignee($assignee);
+        
+        $this->assertSame($user->getId(), $convo->getAssignTo());
+    }
 
     public function testChatConvo()
     {

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -167,7 +167,7 @@ class ConversationTest extends TestCase
         $conversation->setId(12);
         $conversation->setNumber(3526);
         $conversation->setThreadCount(2);
-        $conversation->setAssigneeId(9865);
+        $conversation->setAssignTo(9865);
         $conversation->withAutoRepliesEnabled();
         $conversation->setType('email');
         $conversation->setImported(true);

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -163,16 +163,11 @@ class ConversationTest extends TestCase
 
     public function testExtract()
     {
-        $assignee = new User();
-        $assignee->setId(9865);
-        $assignee->setFirstName('Mr');
-        $assignee->setLastName('Robot');
-
         $conversation = new Conversation();
         $conversation->setId(12);
         $conversation->setNumber(3526);
         $conversation->setThreadCount(2);
-        $conversation->setAssigneeId($assignee->getId());
+        $conversation->setAssigneeId(9865);
         $conversation->withAutoRepliesEnabled();
         $conversation->setType('email');
         $conversation->setImported(true);
@@ -210,8 +205,11 @@ class ConversationTest extends TestCase
         $customer->setEmails($emails);
         $conversation->setCustomer($customer);
 
-        
-        $conversation->setAssignee($assignee);
+        $user = new User();
+        $user->setId(9865);
+        $user->setFirstName('Mr');
+        $user->setLastName('Robot');
+        $conversation->setAssignee($user);
 
         $customField = new CustomField();
         $customField->setId(936);


### PR DESCRIPTION
Changelog:

- Calling `$conversation->setAssignee($user)` will internally call `$this->setAssignTo($user->getId());`
- Note about deprecating `setAssignTo()` to a more descriptive `setAssigneeId()` 
- Tests updated to reflect changes.

Solves Issue #111 