### PR TITLE
Conversation update entities any collection

### DIFF
--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -48,8 +48,8 @@ class ConversationsEndpoint extends Endpoint
     /**
      * Updates the custom field values for a given conversation.  Ommitted fields are removed.
      *
-     * @param int                       $conversationId
-     * @param CustomField[]|Collection  $customFields
+     * @param int                                               $conversationId
+     * @param CustomField[]|Collection|CustomFieldsCollection   $customFields
      */
     public function updateCustomFields(int $conversationId, $customFields): void
     {

--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -48,13 +48,21 @@ class ConversationsEndpoint extends Endpoint
     /**
      * Updates the custom field values for a given conversation.  Ommitted fields are removed.
      *
-     * @param int           $conversationId
-     * @param CustomField[] $customFields
+     * @param int                       $conversationId
+     * @param CustomField[]|Collection  $customFields
      */
-    public function updateCustomFields(int $conversationId, array $customFields): void
+    public function updateCustomFields(int $conversationId, $customFields): void
     {
-        $customFieldsCollection = new CustomFieldsCollection();
-        $customFieldsCollection->setCustomFields($customFields);
+        if ($customFields instanceof CustomFieldsCollection) {
+            $customFieldsCollection = $customFields;
+        } else {
+            if ($customFields instanceof Collection) {
+                $customFields = $customFields->toArray();
+            }
+
+            $customFieldsCollection = new CustomFieldsCollection();
+            $customFieldsCollection->setCustomFields($customFields);
+        }
 
         $this->restClient->updateResource(
             $customFieldsCollection,

--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HelpScout\Api\Conversations;
 
 use HelpScout\Api\Endpoint;
+use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\PagedCollection;
 use HelpScout\Api\Entity\Patch;
 use HelpScout\Api\Http\Hal\HalPagedResources;
@@ -65,13 +66,25 @@ class ConversationsEndpoint extends Endpoint
      * Updates the tags for a given conversation.
      * Omitted tags are removed.
      *
-     * @param int   $conversationId
-     * @param array $tags
+     * @param int                               $conversationId
+     * @param array|Collection|TagsCollection   $tags
      */
-    public function updateTags(int $conversationId, array $tags): void
+    public function updateTags(int $conversationId, $tags): void
     {
-        $tagsCollection = new TagsCollection();
-        $tagsCollection->setTags($tags);
+        if ($tags instanceof TagsCollection) {
+            $tagsCollection = $tags;
+        } else {
+            if ($tags instanceof Collection) {
+                $tagNames = [];
+                foreach ($tags as $tag) {
+                    $tagNames[] = $tag->getName();
+                }
+                $tags = $tagNames;
+            }
+
+            $tagsCollection = new TagsCollection();
+            $tagsCollection->setTags($tags);
+        }
 
         $this->restClient->updateResource(
             $tagsCollection,

--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -48,8 +48,8 @@ class ConversationsEndpoint extends Endpoint
     /**
      * Updates the custom field values for a given conversation.  Ommitted fields are removed.
      *
-     * @param int                                               $conversationId
-     * @param CustomField[]|Collection|CustomFieldsCollection   $customFields
+     * @param int                                             $conversationId
+     * @param CustomField[]|Collection|CustomFieldsCollection $customFields
      */
     public function updateCustomFields(int $conversationId, $customFields): void
     {
@@ -74,8 +74,8 @@ class ConversationsEndpoint extends Endpoint
      * Updates the tags for a given conversation.
      * Omitted tags are removed.
      *
-     * @param int                               $conversationId
-     * @param array|Collection|TagsCollection   $tags
+     * @param int                             $conversationId
+     * @param array|Collection|TagsCollection $tags
      */
     public function updateTags(int $conversationId, $tags): void
     {

--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -48,8 +48,8 @@ class ConversationsEndpoint extends Endpoint
     /**
      * Updates the custom field values for a given conversation.  Ommitted fields are removed.
      *
-     * @param int                                             $conversationId
-     * @param CustomField[]|Collection|CustomFieldsCollection $customFields
+     * @param int                                                   $conversationId
+     * @param CustomField[]|array|Collection|CustomFieldsCollection $customFields
      */
     public function updateCustomFields(int $conversationId, $customFields): void
     {

--- a/tests/Conversations/ConversationIntegrationTest.php
+++ b/tests/Conversations/ConversationIntegrationTest.php
@@ -431,6 +431,31 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
         );
     }
 
+    public function testUpdatesCustomFieldsWithEntityCollectionOfCustomFields()
+    {
+        $this->stubResponse(
+            $this->getResponse(204)
+        );
+
+        $customField = new CustomField();
+        $customField->setId(10524);
+        $customField->setValue(new \DateTime('today'));
+
+        $customFields = new Collection([$customField]);
+
+        $this->client->conversations()->updateCustomFields(12, $customFields);
+
+        $fields = new CustomFieldsCollection();
+
+        $fields->setCustomFields($customFields->toArray());
+
+        $this->verifyRequestWithData(
+            'https://api.helpscout.net/v2/conversations/12/fields',
+            'PUT',
+            $fields->extract()
+        );
+    }
+
     public function testUpdatesTagsWithArrayOfTagNames()
     {
         $this->stubResponse(

--- a/tests/Conversations/ConversationIntegrationTest.php
+++ b/tests/Conversations/ConversationIntegrationTest.php
@@ -13,6 +13,7 @@ use HelpScout\Api\Conversations\Threads\Thread;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Mailboxes\Mailbox;
+use HelpScout\Api\Tags\Tag;
 use HelpScout\Api\Tags\TagsCollection;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 use HelpScout\Api\Tests\Payloads\ConversationPayloads;
@@ -430,7 +431,7 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
         );
     }
 
-    public function testUpdatesTags()
+    public function testUpdatesTagsWithArrayOfTagNames()
     {
         $this->stubResponse(
             $this->getResponse(204)
@@ -444,6 +445,47 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
             'https://api.helpscout.net/v2/conversations/14/tags',
             'PUT',
             $tags->extract()
+        );
+    }
+
+    public function testUpdatesTagsWithTagCollection()
+    {
+        $this->stubResponse(
+            $this->getResponse(204)
+        );
+
+        $tags = new TagsCollection();
+        $tags->setTags(['Support']);
+
+        $this->client->conversations()->updateTags(14, $tags);
+
+        $this->verifyRequestWithData(
+            'https://api.helpscout.net/v2/conversations/14/tags',
+            'PUT',
+            $tags->extract()
+        );
+    }
+
+    public function testUpdatesTagsWithEntityCollectionOfTags()
+    {
+        $this->stubResponse(
+            $this->getResponse(204)
+        );
+
+        $tag = new Tag();
+        $tag->setName('Support');
+        $tags = new Collection([$tag]);
+
+        $this->client->conversations()->updateTags(14, $tags);
+
+        $this->verifyRequestWithData(
+            'https://api.helpscout.net/v2/conversations/14/tags',
+            'PUT',
+            [
+                'tags' => [
+                    'Support',
+                ],
+            ]
         );
     }
 }


### PR DESCRIPTION
`$client->conversations()->updateTags($conversation, $tags);` and `$client->conversations()->updateCustomFields($conversation, $customFields);` both were strongly typed to accept an `array` of tags/fields.  This actually creates some challenges because when fetching a conversation the tags come back in a `Collection` and adding tags uses a `TagCollection` due to the response/request body format.

This PR updates both update methods to accept various collections so the SDK is a bit more flexible and developers don't have to worry about which collection they're passing to the update methods.