### PR TITLE
Conversation hydration support via Webhooks 

### DIFF
--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -239,7 +239,13 @@ class Conversation implements Extractable, Hydratable
             $this->tags = new Collection();
             foreach ($data['tags'] as $tagData) {
                 $tag = new Tag();
-                $tag->hydrate($tagData);
+
+                // Webhooks only return the tag name itself, not all the tag attributes
+                if (is_array($tagData)) {
+                    $tag->hydrate($tagData);
+                } else {
+                    $tag->setName($tagData);
+                }
                 $this->tags->append($tag);
             }
         }

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -178,7 +178,7 @@ class Conversation implements Extractable, Hydratable
             if (is_numeric($data['threads'])) {
                 $this->setThreadCount($data['threads']);
             } elseif (is_array($data['threads'])) {
-                $this->threadse = new Collection();
+                $this->threads = new Collection();
                 foreach ($data['threads'] as $threadData) {
                     $thread = new Thread();
                     $thread->hydrate($threadData);

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -200,7 +200,6 @@ class Conversation implements Extractable, Hydratable
             $mailbox = new Mailbox();
             $mailbox->hydrate($data['mailbox']);
             $this->setMailbox($mailbox);
-            
             // Sometimes in the API we only get the id, so we also have a getMailboxId().  To avoid confusion as to why that
             // method isn't returning the Mailbox id we'll also set that id here.
             $this->setMailboxId($mailbox->getId());

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -177,7 +177,7 @@ class Conversation implements Extractable, Hydratable
             // On some API calls these value is used to pass the thread count
             if (is_numeric($data['threads'])) {
                 $this->setThreadCount($data['threads']);
-            } else if(is_array($data['threads'])) {
+            } elseif (is_array($data['threads'])) {
                 $this->threadse = new Collection();
                 foreach ($data['threads'] as $threadData) {
                     $thread = new Thread();

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -195,11 +195,14 @@ class Conversation implements Extractable, Hydratable
         $this->setPreview($data['preview'] ?? null);
         $this->setMailboxId($data['mailboxId'] ?? null);
 
-        // Hydrating a Conversation from a webhook it'll have a Mailbox
+        // Webhook responses contain a full Mailbox object, not just the ID
         if (isset($data['mailbox'])) {
             $mailbox = new Mailbox();
             $mailbox->hydrate($data['mailbox']);
             $this->setMailbox($mailbox);
+            
+            // Sometimes in the API we only get the id, so we also have a getMailboxId().  To avoid confusion as to why that
+            // method isn't returning the Mailbox id we'll also set that id here.
             $this->setMailboxId($mailbox->getId());
         }
 

--- a/src/Mailboxes/Mailbox.php
+++ b/src/Mailboxes/Mailbox.php
@@ -81,12 +81,10 @@ class Mailbox implements Hydratable
     }
 
     /**
-     * @param int $id
+     * @param int|null $id
      */
-    public function setId(int $id)
+    public function setId($id)
     {
-        Assert::greaterThan($id, 0);
-
         $this->id = $id;
     }
 
@@ -159,11 +157,11 @@ class Mailbox implements Hydratable
     }
 
     /**
-     * @param string $slug
+     * @param string|null $slug
      *
      * @return Mailbox
      */
-    public function setSlug(string $slug): Mailbox
+    public function setSlug($slug): Mailbox
     {
         $this->slug = $slug;
 
@@ -179,11 +177,11 @@ class Mailbox implements Hydratable
     }
 
     /**
-     * @param string $email
+     * @param string|null $email
      *
      * @return Mailbox
      */
-    public function setEmail(string $email): Mailbox
+    public function setEmail($email): Mailbox
     {
         $this->email = $email;
 

--- a/src/Mailboxes/Mailbox.php
+++ b/src/Mailboxes/Mailbox.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace HelpScout\Api\Mailboxes;
 
 use DateTime;
-use HelpScout\Api\Assert\Assert;
 use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\Hydratable;
 use HelpScout\Api\Mailboxes\Entry\Field;

--- a/tests/Conversations/ConversationIntegrationTest.php
+++ b/tests/Conversations/ConversationIntegrationTest.php
@@ -456,6 +456,28 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
         );
     }
 
+    public function testUpdatesCustomFieldsWithCustomFieldsCollection()
+    {
+        $this->stubResponse(
+            $this->getResponse(204)
+        );
+
+        $customField = new CustomField();
+        $customField->setId(10524);
+        $customField->setValue(new \DateTime('today'));
+
+        $customFieldsCollection = new CustomFieldsCollection();
+        $customFieldsCollection->setCustomFields([$customField]);
+
+        $this->client->conversations()->updateCustomFields(14, $customFieldsCollection);
+
+        $this->verifyRequestWithData(
+            'https://api.helpscout.net/v2/conversations/14/fields',
+            'PUT',
+            $customFieldsCollection->extract()
+        );
+    }
+
     public function testUpdatesTagsWithArrayOfTagNames()
     {
         $this->stubResponse(

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -470,7 +470,9 @@ class ConversationTest extends TestCase
         "customer-address@gmail.com"
     ],
     "bcc": null,
-    "tags": [],
+    "tags": [
+        "new-customer"
+    ],
     "threads": [
     {
         "id": 2198262392,
@@ -542,6 +544,9 @@ EOF;
 
         $thread = $conversation->getThreads()[0];
         $this->assertSame(2198262392, $thread->getId());
+
+        $tag = $conversation->getTags()[0];
+        $this->assertSame('new-customer', $tag->getName());
     }
 
 }

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -12,6 +12,7 @@ use HelpScout\Api\Conversations\CustomerWaitingSince;
 use HelpScout\Api\Conversations\CustomField;
 use HelpScout\Api\Conversations\EmailConversation;
 use HelpScout\Api\Conversations\PhoneConversation;
+use HelpScout\Api\Conversations\Status;
 use HelpScout\Api\Conversations\Threads\ChatThread;
 use HelpScout\Api\Conversations\Threads\Thread;
 use HelpScout\Api\Customers\Customer;
@@ -94,7 +95,7 @@ class ConversationTest extends TestCase
         $this->assertSame(15473, $conversation->getNumber());
         $this->assertSame('email', $conversation->getType());
         $this->assertSame(493, $conversation->getFolderId());
-        $this->assertSame('closed', $conversation->getStatus());
+        $this->assertSame(Status::CLOSED, $conversation->getStatus());
         $this->assertSame('published', $conversation->getState());
         $this->assertSame('Need Help', $conversation->getSubject());
         $this->assertSame("I'm having a hard time resolving this", $conversation->getPreview());
@@ -424,4 +425,123 @@ class ConversationTest extends TestCase
         $convo->addThread($thread);
         $this->assertSame($thread, $convo->getThreads()->toArray()[0]);
     }
+
+    public function testHydratesConversationFromWebhookRequest()
+    {
+        $json = <<<EOF
+{
+    "number": 123,
+    "id": 4934923493,
+    "folderId": 14932,
+    "type": "email",
+    "isDraft": false,
+    "owner": null,
+    "mailbox": {
+        "id": 12334,
+        "name": "Sales"
+    },
+    "customer": {
+        "id": 179783313,
+        "firstName": "John",
+        "lastName": "Smith",
+        "email": "john@ourcompany.com",
+        "type": "customer"
+    },
+    "threadCount": 3,
+    "status": "active",
+    "subject": "Re: Following up on your Demo Request",
+    "preview": "Are you still interested in a demo?",
+    "createdBy": {
+        "id": 179783313,
+        "firstName": "John",
+        "lastName": "Smith",
+        "email": "john@ourcompany.com",
+        "type": "customer"
+    },
+    "createdAt": "2019-02-28T15:41:12Z",
+    "modifiedAt": "2019-04-15T20:15:32Z",
+    "closedAt": null,
+    "closedBy": null,
+    "source": {
+        "type": "email",
+        "via": "customer"
+    },
+    "cc": [
+        "customer-address@gmail.com"
+    ],
+    "bcc": null,
+    "tags": [],
+    "threads": [
+    {
+        "id": 2198262392,
+        "assignedTo": null,
+        "status": "active",
+        "createdAt": "2019-02-28T15:48:20Z",
+        "createdBy": {
+            "id": 179783313,
+            "firstName": "John",
+            "lastName": "Smith",
+            "email": "john@ourcompany.com",
+            "type": "customer"
+        },
+        "source": {
+            "type": "email",
+            "via": "customer"
+        },
+        "actionType": null,
+        "actionSourceId": 0,
+        "fromMailbox": null,
+        "type": "customer",
+        "state": "published",
+        "customer": {
+            "id": 179783313,
+            "firstName": "Casey",
+            "lastName": "Lockwood",
+            "email": "casey@helpscout.com",
+            "type": "customer"
+        },
+        "body": "Are you still interested in a demo?",
+        "to": [
+            "customer-address@gmail.com"
+        ],
+        "cc": null,
+        "bcc": null,
+        "attachments": null
+    }
+    ],
+    "customFields": []
+}
+EOF;
+
+        $json = json_decode($json, true);
+        $conversation = new Conversation();
+        $conversation->hydrate($json);
+
+        $this->assertSame(4934923493, $conversation->getId());
+        $this->assertSame(3, $conversation->getThreadCount());
+        $this->assertSame(123, $conversation->getNumber());
+        $this->assertSame('email', $conversation->getType());
+        $this->assertSame(14932, $conversation->getFolderId());
+        $this->assertSame(Status::ACTIVE, $conversation->getStatus());
+        $this->assertSame('Re: Following up on your Demo Request', $conversation->getSubject());
+        $this->assertSame("Are you still interested in a demo?", $conversation->getPreview());
+        $this->assertSame(12334, $conversation->getMailboxId());
+        $this->assertSame(12334, $conversation->getMailbox()->getId());
+
+        $customer = $conversation->getCreatedByCustomer();
+        $this->assertSame(179783313, $customer->getId());
+
+        $this->assertSame('email', $conversation->getSourceType());
+        $this->assertSame('customer', $conversation->getSourceVia());
+
+        $this->assertSame([
+            'customer-address@gmail.com',
+        ], $conversation->getCC());
+
+        $this->assertSame(179783313, $conversation->getCustomer()->getId());
+
+        $thread = $conversation->getThreads()[0];
+        $this->assertSame(2198262392, $thread->getId());
+    }
+
 }

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -526,7 +526,7 @@ EOF;
         $this->assertSame(14932, $conversation->getFolderId());
         $this->assertSame(Status::ACTIVE, $conversation->getStatus());
         $this->assertSame('Re: Following up on your Demo Request', $conversation->getSubject());
-        $this->assertSame("Are you still interested in a demo?", $conversation->getPreview());
+        $this->assertSame('Are you still interested in a demo?', $conversation->getPreview());
         $this->assertSame(12334, $conversation->getMailboxId());
         $this->assertSame(12334, $conversation->getMailbox()->getId());
 
@@ -548,5 +548,4 @@ EOF;
         $tag = $conversation->getTags()[0];
         $this->assertSame('new-customer', $tag->getName());
     }
-
 }


### PR DESCRIPTION
This PR resolves https://github.com/helpscout/helpscout-api-php/issues/95 where a `Conversation` was not properly being hydrated when working with a webhook callback.

I also added a test for `$conversation->updateCustomFields()` because we had 1 line uncovered.