### PR TITLE
Now using the correct query string parameter for custom fields

### DIFF
--- a/src/Conversations/ConversationFilters.php
+++ b/src/Conversations/ConversationFilters.php
@@ -87,7 +87,7 @@ class ConversationFilters
         }
 
         if (\is_array($this->customFieldIds)) {
-            $params['customFieldIds'] = implode(',', $this->customFieldIds);
+            $params['customFieldsByIds'] = implode(',', $this->customFieldIds);
         }
 
         // Filter out null values

--- a/tests/Conversations/ConversationFiltersTest.php
+++ b/tests/Conversations/ConversationFiltersTest.php
@@ -45,7 +45,7 @@ class ConversationFiltersTest extends TestCase
             'sortOrder' => 'asc',
             'query' => 'query',
             'tag' => 'testing',
-            'customFieldIds' => '123:blue',
+            'customFieldsByIds' => '123:blue',
         ], $filters->getParams());
     }
 
@@ -59,7 +59,7 @@ class ConversationFiltersTest extends TestCase
                 '11:none-more-black',
             ]);
         $this->assertSame([
-            'customFieldIds' => '123:blue,456:yellow,789:red,11:none-more-black',
+            'customFieldsByIds' => '123:blue,456:yellow,789:red,11:none-more-black',
         ], $filters->getParams());
     }
 


### PR DESCRIPTION
Resolves https://github.com/helpscout/helpscout-api-php/issues/129 where a user reported we were using the incorrect query parameter according to the api docs.