### PR TITLE
Upgraded to phpunit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 ./examples/_credentials.php
 build
 .DS_Store
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.0",
         "phpstan/phpstan": "^0.10.1",
         "friendsofphp/php-cs-fixer": "^2.3",
         "mockery/mockery": "^1.1"

--- a/tests/ApiClientIntegrationTestCase.php
+++ b/tests/ApiClientIntegrationTestCase.php
@@ -40,7 +40,7 @@ abstract class ApiClientIntegrationTestCase extends TestCase
      */
     protected $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->history = [];
         $this->mockHandler = new MockHandler();

--- a/tests/ApiClientTest.php
+++ b/tests/ApiClientTest.php
@@ -38,7 +38,7 @@ class ApiClientTest extends TestCase
      */
     private $guzzle;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->authenticator = Mockery::mock(Authenticator::class);
         $this->guzzle = Mockery::mock(Client::class);

--- a/tests/Authentication/AuthenticationIntegrationTest.php
+++ b/tests/Authentication/AuthenticationIntegrationTest.php
@@ -25,7 +25,7 @@ class AuthenticationIntegrationTest extends ApiClientIntegrationTestCase
      */
     protected $guzzle;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Conversations/Threads/Attachments/AttachmentFactoryTest.php
+++ b/tests/Conversations/Threads/Attachments/AttachmentFactoryTest.php
@@ -17,7 +17,7 @@ class AttachmentFactoryTest extends TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject|Filesystem */
     private $filesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Conversations/Threads/Support/HasCustomerTest.php
+++ b/tests/Conversations/Threads/Support/HasCustomerTest.php
@@ -12,7 +12,7 @@ class HasCustomerTest extends TestCase
 {
     use HasCustomer;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Conversations/Threads/Support/HasPartiesToBeNotifiedTest.php
+++ b/tests/Conversations/Threads/Support/HasPartiesToBeNotifiedTest.php
@@ -11,7 +11,7 @@ class HasPartiesToBeNotifiedTest extends TestCase
 {
     use HasPartiesToBeNotified;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Conversations/Threads/Support/HasUserTest.php
+++ b/tests/Conversations/Threads/Support/HasUserTest.php
@@ -12,7 +12,7 @@ class HasUserTest extends TestCase
 {
     use HasUser;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Conversations/Threads/ThreadFactoryTest.php
+++ b/tests/Conversations/Threads/ThreadFactoryTest.php
@@ -18,7 +18,7 @@ class ThreadFactoryTest extends TestCase
     /** @var ThreadFactory */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -280,9 +280,9 @@ class CustomerTest extends TestCase
 
         $customer->addEmail($email);
 
-        $this->assertArraySubset([
-            'email' => 'tester@mysite.com',
-        ], $customer->extract());
+        $extracted = $customer->extract();
+        $this->assertArrayHasKey('email', $extracted);
+        $this->assertEquals('tester@mysite.com', $extracted['email']);
     }
 
     public function testExtractNewEntity()

--- a/tests/Entity/PagedCollectionTest.php
+++ b/tests/Entity/PagedCollectionTest.php
@@ -32,7 +32,7 @@ class PagedCollectionTest extends TestCase
      */
     private $collection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->loadedCollection = Mockery::mock(PagedCollection::class);
         $this->pageLoader = new PageLoaderStub($this->loadedCollection);

--- a/tests/Http/AuthenticatorTest.php
+++ b/tests/Http/AuthenticatorTest.php
@@ -16,7 +16,7 @@ class AuthenticatorTest extends TestCase
     /** @var MockInterface */
     public $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = Mockery::mock(Client::class);
     }

--- a/tests/Http/RestClientTest.php
+++ b/tests/Http/RestClientTest.php
@@ -28,7 +28,7 @@ class RestClientTest extends TestCase
     public $methodsClient;
     public $authenticator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->methodsClient = \Mockery::mock(Client::class);
         $this->authenticator = \Mockery::mock(Authenticator::class);

--- a/tests/Tags/TagsCollectionTest.php
+++ b/tests/Tags/TagsCollectionTest.php
@@ -22,6 +22,6 @@ class TagsCollectionTest extends TestCase
 
         $extracted = $tagsCollection->extract();
         $this->assertArrayHasKey('tags', $extracted);
-        $this->assertContains('Support', $extracted['tags'][0]);
+        $this->assertStringContainsString('Support', $extracted['tags'][0]);
     }
 }


### PR DESCRIPTION
We're now using phpunit v8, which included some `void` strongly typed return values as well as adjusting a few assertions to avoid deprecated methods.