### PR TITLE
Added documentation/examples for how to refresh an expired token

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ $client->setAccessToken('asdfasdf');
 ```
 The access token will always be used if available, regardless of whether you have other credentials set or not.
 
+### Refreshing Expired Tokens
+
+While making API calls, if your token comes back expired you can refresh the token by:
+
+```
+$client->getAuthenticator()->fetchAccessAndRefreshToken();
+```
+
+To persist the updated token you can use the authenticator that is returned:
+
+```
+$client->getAuthenticator()->fetchAccessAndRefreshToken()->getTokens(); // array
+```
+
 ### Authorization Code Flow
 
 Because the [authorization code](https://developer.helpscout.com/mailbox-api/overview/authentication/#authorization-code-flow) is only good for a single use, you'll need to exchange the code for and access token and refresh token prior to making additional api calls.  You'll also need to persist the tokens for reuse later.

--- a/examples/auth.php
+++ b/examples/auth.php
@@ -4,8 +4,10 @@ require '_credentials.php';
 
 use HelpScout\Api\ApiClientFactory;
 
-
-// See https://developer.helpscout.com/mailbox-api/overview/authentication/#authorization-code-flow
+/**
+ * Using Authorization Code flow
+ * @see https://developer.helpscout.com/mailbox-api/overview/authentication/#authorization-code-flow
+ */
 $appId = '';
 $appSecret = '';
 $authorizationCode = '';
@@ -22,3 +24,14 @@ var_dump($client->getAuthenticator()->getTokens());
 // Additional requests after exchanging the code use the access/refresh tokens
 $users = $client->users()->list();
 print_r($users->getFirstPage()->toArray());
+
+/**
+ * Refreshing an expired token
+ */
+$refreshToken = '';
+$client->useRefreshToken(
+    $appId,
+    $appSecret,
+    $refreshToken
+);
+$newTokens = $client->getAuthenticator()->fetchAccessAndRefreshToken()->getTokens();

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -197,7 +197,7 @@ class Authenticator
         }
     }
 
-    public function fetchAccessAndRefreshToken(): void
+    public function fetchAccessAndRefreshToken(): self
     {
         $tokens = $this->requestAuthTokens(
             $this->auth->getPayload(),
@@ -207,6 +207,8 @@ class Authenticator
         $this->accessToken = $tokens['access_token'];
         $this->ttl = $tokens['expires_in'];
         $this->refreshToken = $tokens['refresh_token'] ?? null;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
https://github.com/helpscout/helpscout-api-php/issues/128 points out that we could use more clarity around how to refresh an expired token so this PR adds an example as well as updates our README.