### PR TITLE
UTC conversion and timestamp format adjustment

### DIFF
--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -15,6 +15,7 @@ use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
 use HelpScout\Api\Mailboxes\Mailbox;
+use HelpScout\Api\Support\ExtractsData;
 use HelpScout\Api\Support\HydratesData;
 use HelpScout\Api\Tags\Tag;
 use HelpScout\Api\Users\User;
@@ -22,6 +23,7 @@ use HelpScout\Api\Users\User;
 class Conversation implements Extractable, Hydratable
 {
     use HydratesData,
+        ExtractsData,
         HasPartiesToBeNotified,
         IncludesThreadDetails,
         HasCustomer;
@@ -348,15 +350,15 @@ class Conversation implements Extractable, Hydratable
         }
 
         if ($this->getCreatedAt() != null) {
-            $data['createdAt'] = $this->getCreatedAt()->format('c');
+            $data['createdAt'] = $this->to8601Utc($this->getCreatedAt());
         }
 
         if ($this->getClosedAt() != null) {
-            $data['closedAt'] = $this->getClosedAt()->format('c');
+            $data['closedAt'] = $this->to8601Utc($this->getClosedAt());
         }
 
         if ($this->getUserUpdatedAt() != null) {
-            $data['userUpdatedAt'] = $this->getUserUpdatedAt()->format('c');
+            $data['userUpdatedAt'] = $this->to8601Utc($this->getUserUpdatedAt());
         }
 
         if ($this->wasCreatedByCustomer()) {

--- a/src/Conversations/CustomerWaitingSince.php
+++ b/src/Conversations/CustomerWaitingSince.php
@@ -7,11 +7,13 @@ namespace HelpScout\Api\Conversations;
 use DateTime;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
+use HelpScout\Api\Support\ExtractsData;
 use HelpScout\Api\Support\HydratesData;
 
 class CustomerWaitingSince implements Extractable, Hydratable
 {
-    use HydratesData;
+    use HydratesData,
+        ExtractsData;
 
     /**
      * @var DateTime
@@ -47,7 +49,7 @@ class CustomerWaitingSince implements Extractable, Hydratable
         ];
 
         if ($this->getTime() instanceof DateTime) {
-            $fields['time'] = $this->getTime()->format('c');
+            $fields['time'] = $this->to8601Utc($this->getTime());
         }
 
         return $fields;

--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -12,11 +12,13 @@ use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
 use HelpScout\Api\Exception\RuntimeException;
+use HelpScout\Api\Support\ExtractsData;
 use HelpScout\Api\Support\HydratesData;
 
 class Thread implements Extractable, Hydratable
 {
     use HydratesData,
+        ExtractsData,
         HasPartiesToBeNotified,
         IncludesThreadDetails;
 
@@ -200,11 +202,11 @@ class Thread implements Extractable, Hydratable
         $data['bcc'] = $this->getBCC();
 
         if ($this->getCreatedAt() != null) {
-            $data['createdAt'] = $this->getCreatedAt()->format('c');
+            $data['createdAt'] = $this->to8601Utc($this->getCreatedAt());
         }
 
         if ($this->getOpenedAt() != null) {
-            $data['openedAt'] = $this->getOpenedAt()->format('c');
+            $data['openedAt'] = $this->to8601Utc($this->getOpenedAt());
         }
 
         if ($this->isImported()) {

--- a/src/Entity/Extractable.php
+++ b/src/Entity/Extractable.php
@@ -6,7 +6,5 @@ namespace HelpScout\Api\Entity;
 
 interface Extractable
 {
-    public const DATETIME_FORMAT = 'Y-m-d\TH:i:s\Z';
-
     public function extract(): array;
 }

--- a/src/Mailboxes/Mailbox.php
+++ b/src/Mailboxes/Mailbox.php
@@ -140,7 +140,7 @@ class Mailbox implements Hydratable
      *
      * @return Mailbox
      */
-    public function setName(string $name): Mailbox
+    public function setName($name): Mailbox
     {
         $this->name = $name;
 

--- a/src/Support/ExtractsData.php
+++ b/src/Support/ExtractsData.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Support;
+
+use DateTime;
+use HelpScout\Api\Exception\InvalidArgumentException;
+
+trait ExtractsData
+{
+    /**
+     * Convert DateTime to a particular version of the 8601 spec in UTC.
+     *
+     * @see https://developer.helpscout.com/mailbox-api/overview/time/
+     */
+    private function to8601Utc(\DateTimeInterface $dateTime): string
+    {
+        // Convert to UTC if we can
+        if ($dateTime instanceof DateTime) {
+            $dateTime->setTimezone(new \DateTimeZone('UTC'));
+        } else if ($dateTime instanceof \DateTimeImmutable && $dateTime->getOffset() > 0) {
+            // Some implementations will be wrong since we're effectively dropping the offset from the datetime format
+            // and this interface doesn't allow us to make modifications so we reject the timestamp altogether to ensure
+            // only correct timestamps make it through.
+            throw new InvalidArgumentException('Timestamp must be UTC');
+        }
+
+        // PHP's default 8601 format contains a portion that includes the timezone offset.  The Mailbox API doesn't
+        // like the offset and requires a timestamp without it, thus requiring all inbound timestamps to be UTC
+        return $dateTime->format('Y-m-d\TH:i:s\Z');
+    }
+}

--- a/src/Support/ExtractsData.php
+++ b/src/Support/ExtractsData.php
@@ -19,7 +19,7 @@ trait ExtractsData
         // Convert to UTC if we can
         if ($dateTime instanceof DateTime) {
             $dateTime->setTimezone(new \DateTimeZone('UTC'));
-        } else if ($dateTime instanceof \DateTimeImmutable && $dateTime->getOffset() > 0) {
+        } elseif ($dateTime instanceof \DateTimeImmutable && $dateTime->getOffset() > 0) {
             // Some implementations will be wrong since we're effectively dropping the offset from the datetime format
             // and this interface doesn't allow us to make modifications so we reject the timestamp altogether to ensure
             // only correct timestamps make it through.

--- a/src/Tags/Tag.php
+++ b/src/Tags/Tag.php
@@ -6,11 +6,13 @@ namespace HelpScout\Api\Tags;
 
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
+use HelpScout\Api\Support\ExtractsData;
 use HelpScout\Api\Support\HydratesData;
 
 class Tag implements Extractable, Hydratable
 {
-    use HydratesData;
+    use HydratesData,
+        ExtractsData;
 
     /**
      * @var string|null
@@ -82,11 +84,11 @@ class Tag implements Extractable, Hydratable
         ];
 
         if ($this->getCreatedAt() !== null) {
-            $data['createdAt'] = $this->getCreatedAt()->format(Extractable::DATETIME_FORMAT);
+            $data['createdAt'] = $this->to8601Utc($this->getCreatedAt());
         }
 
         if ($this->getUpdatedAt() !== null) {
-            $data['updatedAt'] = $this->getUpdatedAt()->format(Extractable::DATETIME_FORMAT);
+            $data['updatedAt'] = $this->to8601Utc($this->getUpdatedAt());
         }
 
         return $data;

--- a/src/Workflows/Workflow.php
+++ b/src/Workflows/Workflow.php
@@ -7,11 +7,13 @@ namespace HelpScout\Api\Workflows;
 use HelpScout\Api\Assert\Assert;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
+use HelpScout\Api\Support\ExtractsData;
 use HelpScout\Api\Support\HydratesData;
 
 class Workflow implements Hydratable, Extractable
 {
-    use HydratesData;
+    use HydratesData,
+        ExtractsData;
 
     public const TYPE_MANUAL = 'manual';
     public const TYPE_AUTOMATIC = 'automatic';
@@ -91,11 +93,11 @@ class Workflow implements Hydratable, Extractable
         ];
 
         if ($this->getCreatedAt() !== null) {
-            $data['createdAt'] = $this->getCreatedAt()->format(Extractable::DATETIME_FORMAT);
+            $data['createdAt'] = $this->to8601Utc($this->getCreatedAt());
         }
 
         if ($this->getModifiedAt() !== null) {
-            $data['modifiedAt'] = $this->getModifiedAt()->format(Extractable::DATETIME_FORMAT);
+            $data['modifiedAt'] = $this->to8601Utc($this->getModifiedAt());
         }
 
         return $data;

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -257,10 +257,10 @@ class ConversationTest extends TestCase
                 'id' => 12,
                 'type' => 'customer',
             ],
-            'createdAt' => '2017-04-21T14:39:56+00:00',
-            'closedAt' => '2017-04-21T12:23:06+00:00',
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'closedAt' => '2017-04-21T12:23:06Z',
             'closedBy' => 14,
-            'userUpdatedAt' => '2017-04-21T03:12:06+00:00',
+            'userUpdatedAt' => '2017-04-21T03:12:06Z',
             'source' => [
                 'type' => 'email',
                 'via' => 'customer',
@@ -276,7 +276,7 @@ class ConversationTest extends TestCase
                 'email' => 'mycustomer@domain.com',
             ],
             'customerWaitingSince' => [
-                'time' => '2012-07-24T20:18:33+00:00',
+                'time' => '2012-07-24T20:18:33Z',
                 'friendly' => '20 hours ago',
                 'latestReplyFrom' => 'customer',
             ],

--- a/tests/Conversations/CustomerWaitingSinceTest.php
+++ b/tests/Conversations/CustomerWaitingSinceTest.php
@@ -32,7 +32,7 @@ class CustomerWaitingSinceTest extends TestCase
         $waitingSince->setLatestReplyFrom('customer');
 
         $this->assertSame([
-            'time' => '2017-07-24T20:18:33+00:00',
+            'time' => '2017-07-24T20:18:33Z',
             'friendly' => '20 hours ago',
             'latestReplyFrom' => 'customer',
         ], $waitingSince->extract());

--- a/tests/Conversations/Threads/ThreadTest.php
+++ b/tests/Conversations/Threads/ThreadTest.php
@@ -236,8 +236,8 @@ class ThreadTest extends TestCase
             'bcc' => [
                 'bear@secret.com',
             ],
-            'createdAt' => '2017-04-21T14:39:56+00:00',
-            'openedAt' => '2017-04-21T14:12:56+00:00',
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'openedAt' => '2017-04-21T14:12:56Z',
             'imported' => true,
         ], $thread->extract());
     }

--- a/tests/Support/ExtractsDataTest.php
+++ b/tests/Support/ExtractsDataTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Support;
 
 use DateTime;
-use DateTimeZone;
 use DateTimeImmutable;
+use DateTimeZone;
 use HelpScout\Api\Exception\InvalidArgumentException;
 use HelpScout\Api\Support\ExtractsData;
 use PHPUnit\Framework\TestCase;

--- a/tests/Support/ExtractsDataTest.php
+++ b/tests/Support/ExtractsDataTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Support;
+
+use DateTime;
+use DateTimeZone;
+use DateTimeImmutable;
+use HelpScout\Api\Exception\InvalidArgumentException;
+use HelpScout\Api\Support\ExtractsData;
+use PHPUnit\Framework\TestCase;
+
+class ExtractsDataTest extends TestCase
+{
+    use ExtractsData;
+
+    public function testConvertsTimestampToExpectedFormat()
+    {
+        $dateTime = new DateTime('1 hour ago');
+
+        $this->assertEquals(0, $dateTime->getOffset());
+        $this->assertEquals($dateTime->format('Y-m-d\TH:i:s\Z'), $this->to8601Utc($dateTime));
+    }
+
+    public function testConvertsTimestampToUTC()
+    {
+        $dateTime = new DateTime('1 hour ago');
+        $dateTime->setTimezone(new DateTimeZone('Europe/Zurich'));
+
+        $this->assertGreaterThan(0, $dateTime->getOffset());
+
+        $expectedUTC = clone $dateTime;
+        $expectedUTC->sub(date_interval_create_from_date_string('2 hours'));
+        $this->assertEquals($expectedUTC->format('Y-m-d\TH:i:s\Z'), $this->to8601Utc($dateTime));
+    }
+
+    public function testRejectsTimestampsWithoutUTC()
+    {
+        $this->expectExceptionMessage('Timestamp must be UTC');
+        $this->expectException(InvalidArgumentException::class);
+
+        $dateTime = new DateTimeImmutable('1 hour ago', new DateTimeZone('Europe/Zurich'));
+
+        $this->to8601Utc($dateTime);
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/helpscout/helpscout-api-php/issues/138

@tompedals Looks like a `Tag` originally had the timestamp handling correctly but we didn't reproduce that correct handling of timestamps elsewhere.  This PR expands that so all entities use the correct timestamp format but also centralizes the UTC timestamp conversion to reduce the chances a developer overlooks doing the conversion on prior to passing it off to our SDK.