### PR TITLE
User agent now provides php version and SDK version numbers

### DIFF
--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -6,6 +6,7 @@ namespace HelpScout\Api\Http;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
+use HelpScout\Api\ApiClient;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Http\Hal\HalDeserializer;
 use HelpScout\Api\Http\Hal\HalResource;
@@ -58,10 +59,13 @@ class RestClient
     /**
      * @return array
      */
-    protected function getDefaultHeaders(): array
+    public function getDefaultHeaders(): array
     {
         return array_merge(
-            ['Content-Type' => self::CONTENT_TYPE],
+            [
+                'Content-Type' => self::CONTENT_TYPE,
+                'User-Agent' => sprintf(self::CLIENT_USER_AGENT, ApiClient::CLIENT_VERSION, phpversion()),
+            ],
             $this->getAuthHeader()
         );
     }

--- a/tests/Http/RestClientTest.php
+++ b/tests/Http/RestClientTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use HelpScout\Api\ApiClient;
 use HelpScout\Api\Http\Auth\ClientCredentials;
 use HelpScout\Api\Http\Auth\LegacyCredentials;
 use HelpScout\Api\Http\Auth\NullCredentials;
@@ -32,6 +33,26 @@ class RestClientTest extends TestCase
     {
         $this->methodsClient = \Mockery::mock(Client::class);
         $this->authenticator = \Mockery::mock(Authenticator::class);
+    }
+
+    public function testDefaultHeaders()
+    {
+        $this->authenticator->shouldReceive('getAuthHeader')->andReturn([
+            'Authorization' => 'Bearer 123abc',
+        ]);
+
+        $restClient = new RestClient($this->methodsClient, $this->authenticator);
+
+        $headers = $restClient->getDefaultHeaders();
+
+        $this->assertArrayHasKey('Content-Type', $headers);
+        $this->assertEquals(RestClient::CONTENT_TYPE, $headers['Content-Type']);
+
+        $this->assertArrayHasKey('User-Agent', $headers);
+        $this->assertEquals('Help Scout PHP API Client/'.ApiClient::CLIENT_VERSION.' (PHP '.phpversion().')', $headers['User-Agent']);
+
+        $this->assertArrayHasKey('Authorization', $headers);
+        $this->assertEquals('Bearer 123abc', $headers['Authorization']);
     }
 
     public function testRunReport()


### PR DESCRIPTION
Resolves https://github.com/helpscout/helpscout-api-php/issues/143.

Great catch on this issue @tompedals!  This also highlights that I haven't been incrementing our ApiClient version number as we've been releasing it.  