### PR TITLE
Use correct report format for 24 hour time

### DIFF
--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -8,7 +8,7 @@ abstract class Report
 {
     public const ENDPOINT = '/v2/reports';
     public const QUERY_FIELDS = [];
-    public const DATE_FORMAT = 'Y-m-d\Th:m:s\Z';
+    public const DATE_FORMAT = 'Y-m-d\TH:m:s\Z';
 
     /**
      * @var ParameterBag

--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -8,7 +8,7 @@ abstract class Report
 {
     public const ENDPOINT = '/v2/reports';
     public const QUERY_FIELDS = [];
-    public const DATE_FORMAT = 'Y-m-d\TH:m:s\Z';
+    public const DATE_FORMAT = 'Y-m-d\TH:i:s\Z';
 
     /**
      * @var ParameterBag


### PR DESCRIPTION
While working with the reports API, I noticed that if I pass a `DateTime` object directly, then the reports will sometimes return an error based on the start and end dates, even if the start and end dates are correct. What I found was that the report format translates to 12 hour time rather than 24 hour time.

This PR uses 24 hour time for the report format.