### PR TITLE
Added channel reports

### DIFF
--- a/src/Reports/Chat.php
+++ b/src/Reports/Chat.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Reports;
+
+class Chat extends Report
+{
+    public const ENDPOINT = '/v2/reports/chat';
+    public const QUERY_FIELDS = [
+        'start',
+        'end',
+        'previousStart',
+        'previousEnd',
+        'mailboxes',
+        'tags',
+        'folders',
+        'officeHours',
+    ];
+}

--- a/src/Reports/Conversations/VolumesByChannel.php
+++ b/src/Reports/Conversations/VolumesByChannel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Reports\Conversations;
+
+use HelpScout\Api\Reports\Report;
+
+class VolumesByChannel extends Report
+{
+    public const ENDPOINT = '/v2/reports/conversations/volume-by-channel';
+    public const QUERY_FIELDS = [
+        'start',
+        'end',
+        'previousStart',
+        'previousEnd',
+        'mailboxes',
+        'tags',
+        'types',
+        'folders',
+        'viewBy',
+    ];
+}

--- a/src/Reports/Email.php
+++ b/src/Reports/Email.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Reports;
+
+class Email extends Report
+{
+    public const ENDPOINT = '/v2/reports/email';
+    public const QUERY_FIELDS = [
+        'start',
+        'end',
+        'previousStart',
+        'previousEnd',
+        'mailboxes',
+        'tags',
+        'folders',
+        'officeHours',
+    ];
+}

--- a/src/Reports/Phone.php
+++ b/src/Reports/Phone.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Reports;
+
+class Phone extends Report
+{
+    public const ENDPOINT = '/v2/reports/phone';
+    public const QUERY_FIELDS = [
+        'start',
+        'end',
+        'previousStart',
+        'previousEnd',
+        'mailboxes',
+        'tags',
+        'folders',
+        'officeHours',
+    ];
+}

--- a/tests/Reports/ChatTest.php
+++ b/tests/Reports/ChatTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Reports\Conversations;
+
+use HelpScout\Api\Reports\Chat;
+use PHPUnit\Framework\TestCase;
+
+class ChatTest extends TestCase
+{
+    public function testConstants()
+    {
+        $endpoint = '/v2/reports/chat';
+        $fields = [
+            'start',
+            'end',
+            'previousStart',
+            'previousEnd',
+            'mailboxes',
+            'tags',
+            'folders',
+            'officeHours',
+        ];
+
+        $this->assertSame($endpoint, Chat::ENDPOINT);
+        $this->assertSame($fields, Chat::QUERY_FIELDS);
+    }
+}

--- a/tests/Reports/ChatTest.php
+++ b/tests/Reports/ChatTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace HelpScout\Api\Tests\Reports\Conversations;
+namespace HelpScout\Api\Tests\Reports;
 
 use HelpScout\Api\Reports\Chat;
 use PHPUnit\Framework\TestCase;

--- a/tests/Reports/Conversations/VolumesByChannelTest.php
+++ b/tests/Reports/Conversations/VolumesByChannelTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Reports\Conversations;
+
+use HelpScout\Api\Reports\Conversations\BusyTimes;
+use HelpScout\Api\Reports\Conversations\VolumesByChannel;
+use PHPUnit\Framework\TestCase;
+
+class VolumesByChannelTest extends TestCase
+{
+    public function testConstants()
+    {
+        $endpoint = '/v2/reports/conversations/volume-by-channel';
+        $fields = [
+            'start',
+            'end',
+            'previousStart',
+            'previousEnd',
+            'mailboxes',
+            'tags',
+            'types',
+            'folders',
+            'viewBy',
+        ];
+
+        $this->assertSame($endpoint, VolumesByChannel::ENDPOINT);
+        $this->assertSame($fields, VolumesByChannel::QUERY_FIELDS);
+    }
+}

--- a/tests/Reports/Conversations/VolumesByChannelTest.php
+++ b/tests/Reports/Conversations/VolumesByChannelTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Reports\Conversations;
 
-use HelpScout\Api\Reports\Conversations\BusyTimes;
 use HelpScout\Api\Reports\Conversations\VolumesByChannel;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Reports/EmailTest.php
+++ b/tests/Reports/EmailTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Reports\Conversations;
 
-use HelpScout\Api\Reports\Conversations\BusyTimes;
-use HelpScout\Api\Reports\Conversations\VolumesByChannel;
 use HelpScout\Api\Reports\Email;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Reports/EmailTest.php
+++ b/tests/Reports/EmailTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Reports\Conversations;
+
+use HelpScout\Api\Reports\Conversations\BusyTimes;
+use HelpScout\Api\Reports\Conversations\VolumesByChannel;
+use HelpScout\Api\Reports\Email;
+use PHPUnit\Framework\TestCase;
+
+class EmailTest extends TestCase
+{
+    public function testConstants()
+    {
+        $endpoint = '/v2/reports/email';
+        $fields = [
+            'start',
+            'end',
+            'previousStart',
+            'previousEnd',
+            'mailboxes',
+            'tags',
+            'folders',
+            'officeHours',
+        ];
+
+        $this->assertSame($endpoint, Email::ENDPOINT);
+        $this->assertSame($fields, Email::QUERY_FIELDS);
+    }
+}

--- a/tests/Reports/EmailTest.php
+++ b/tests/Reports/EmailTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace HelpScout\Api\Tests\Reports\Conversations;
+namespace HelpScout\Api\Tests\Reports;
 
 use HelpScout\Api\Reports\Email;
 use PHPUnit\Framework\TestCase;

--- a/tests/Reports/PhoneTest.php
+++ b/tests/Reports/PhoneTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Reports\Conversations;
+
+use HelpScout\Api\Reports\Conversations\BusyTimes;
+use HelpScout\Api\Reports\Conversations\VolumesByChannel;
+use HelpScout\Api\Reports\Email;
+use HelpScout\Api\Reports\Phone;
+use PHPUnit\Framework\TestCase;
+
+class PhoneTest extends TestCase
+{
+    public function testConstants()
+    {
+        $endpoint = '/v2/reports/phone';
+        $fields = [
+            'start',
+            'end',
+            'previousStart',
+            'previousEnd',
+            'mailboxes',
+            'tags',
+            'folders',
+            'officeHours',
+        ];
+
+        $this->assertSame($endpoint, Phone::ENDPOINT);
+        $this->assertSame($fields, Phone::QUERY_FIELDS);
+    }
+}

--- a/tests/Reports/PhoneTest.php
+++ b/tests/Reports/PhoneTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace HelpScout\Api\Tests\Reports\Conversations;
+namespace HelpScout\Api\Tests\Reports;
 
 use HelpScout\Api\Reports\Phone;
 use PHPUnit\Framework\TestCase;

--- a/tests/Reports/PhoneTest.php
+++ b/tests/Reports/PhoneTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Reports\Conversations;
 
-use HelpScout\Api\Reports\Conversations\BusyTimes;
-use HelpScout\Api\Reports\Conversations\VolumesByChannel;
-use HelpScout\Api\Reports\Email;
 use HelpScout\Api\Reports\Phone;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Some new reports were added for Email, Chat, Phone and All Channels (see https://developer.helpscout.com/mailbox-api/changelog/#2019-05-15-new-new-reports).  This PR adds support for those in the SDK.

 * Added [Conversations -> Volume by Channel Report](https://developer.helpscout.com/mailbox-api/endpoints/reports/conversations/reports-conversations-volume-by-channel/)
 * Added [Email Report](https://developer.helpscout.com/mailbox-api/endpoints/reports/email/)
 * Added [Phone Report](https://developer.helpscout.com/mailbox-api/endpoints/reports/phone/)
 * Added [Chat Report](https://developer.helpscout.com/mailbox-api/endpoints/reports/chat/)