### PR TITLE
Fixed invalid syntax in the threads example

### DIFF
--- a/examples/conversations.php
+++ b/examples/conversations.php
@@ -5,6 +5,7 @@ require '_credentials.php';
 use HelpScout\Api\ApiClientFactory;
 use HelpScout\Api\Conversations\Conversation;
 use HelpScout\Api\Conversations\ConversationFilters;
+use HelpScout\Api\Conversations\ConversationRequest;
 use HelpScout\Api\Conversations\CustomField;
 use HelpScout\Api\Conversations\Threads\ChatThread;
 use HelpScout\Api\Tags\Tag;
@@ -16,6 +17,11 @@ $client = $client->useClientCredentials($appId, $appSecret);
 
 // GET conversation
 $conversation = $client->conversations()->get(12);
+
+// GET conversation with the threads
+$conversationRequest = new ConversationRequest();
+$conversationRequest->withThreads();
+$conversation = $client->conversations()->get(12, $conversationRequest);
 
 // List conversations
 $conversations = $client->conversations()

--- a/examples/threads.php
+++ b/examples/threads.php
@@ -13,7 +13,7 @@ $client = ApiClientFactory::createClient();
 $client->useClientCredentials($appId, $appSecret);
 
 $conversationId = 0;
-$threads = $client->getThreads($conversationId);
+$threads = $client->threads()->list($conversationId);
 
 print_r($threads->getFirstPage()->toArray());
 

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -768,6 +768,10 @@ class Conversation implements Extractable, Hydratable
     }
 
     /**
+     * Obtain the threads that were eagerly loaded when this conversation was obtained.
+     *
+     * @see ConversationRequest
+     *
      * @return Thread[]|Collection
      */
     public function getThreads(): Collection


### PR DESCRIPTION
Addresses an invalid syntax example reported in https://github.com/helpscout/helpscout-api-php/issues/151