### PR TITLE
Attachment links

### DIFF
--- a/src/Conversations/Threads/Attachments/Attachment.php
+++ b/src/Conversations/Threads/Attachments/Attachment.php
@@ -7,6 +7,8 @@ namespace HelpScout\Api\Conversations\Threads\Attachments;
 use HelpScout\Api\Assert\Assert;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
+use HelpScout\Api\Http\Hal\HalDeserializer;
+use HelpScout\Api\Http\Hal\HalLinks;
 
 class Attachment implements Extractable, Hydratable
 {
@@ -44,6 +46,11 @@ class Attachment implements Extractable, Hydratable
      * @var int
      */
     private $size;
+
+    /**
+     * @var string
+     */
+    private $webUrl;
 
     /**
      * @return array
@@ -93,6 +100,16 @@ class Attachment implements Extractable, Hydratable
 
         if (isset($data['size']) && is_numeric($data['size'])) {
             $this->setSize((int) $data['size']);
+        }
+
+        // The web accessible link for this file is pulled in via links
+        if (isset($data[HalDeserializer::LINKS])) {
+            /** @var HalLinks $links */
+            $links = $data[HalDeserializer::LINKS];
+
+            if ($links->has('web')) {
+                $this->setWebUrl($links->getHref('web'));
+            }
         }
     }
 
@@ -193,6 +210,23 @@ class Attachment implements Extractable, Hydratable
     public function setSize(int $size): Attachment
     {
         $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * Get a web accessible URL for this attachment.
+     *
+     * @example https://secure.helpscout.net/file/[attachmentId]/[file-hash]/[filename].[extension]
+     */
+    public function getWebUrl(): ?string
+    {
+        return $this->webUrl;
+    }
+
+    protected function setWebUrl(string $webUrl): Attachment
+    {
+        $this->webUrl = $webUrl;
 
         return $this;
     }

--- a/src/Conversations/Threads/Attachments/AttachmentsEndpoint.php
+++ b/src/Conversations/Threads/Attachments/AttachmentsEndpoint.php
@@ -16,12 +16,12 @@ class AttachmentsEndpoint extends Endpoint
      */
     public function get(int $conversationId, int $attachmentId): Attachment
     {
-        $conversationResource = $this->restClient->getResource(
+        $attachmentResource = $this->restClient->getResource(
             Attachment::class,
             sprintf('/v2/conversations/%d/attachments/%d/data', $conversationId, $attachmentId)
         );
 
-        return $conversationResource->getEntity();
+        return $attachmentResource->getEntity();
     }
 
     /**

--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -12,8 +12,6 @@ use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
 use HelpScout\Api\Exception\RuntimeException;
-use HelpScout\Api\Http\Hal\HalDeserializer;
-use HelpScout\Api\Http\Hal\HalLinks;
 use HelpScout\Api\Support\ExtractsData;
 use HelpScout\Api\Support\HydratesData;
 

--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -12,6 +12,8 @@ use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\Extractable;
 use HelpScout\Api\Entity\Hydratable;
 use HelpScout\Api\Exception\RuntimeException;
+use HelpScout\Api\Http\Hal\HalDeserializer;
+use HelpScout\Api\Http\Hal\HalLinks;
 use HelpScout\Api\Support\ExtractsData;
 use HelpScout\Api\Support\HydratesData;
 
@@ -312,6 +314,11 @@ class Thread implements Extractable, Hydratable
     public function getAttachments(): Collection
     {
         return $this->attachments;
+    }
+
+    public function hasAttachments(): bool
+    {
+        return $this->attachments->count() > 0;
     }
 
     public function setImported(bool $imported): Thread

--- a/src/Http/Hal/HalLinks.php
+++ b/src/Http/Hal/HalLinks.php
@@ -23,11 +23,6 @@ class HalLinks
         }
     }
 
-    /**
-     * @param string $rel
-     *
-     * @return HalLink
-     */
     public function get(string $rel): HalLink
     {
         if (!$this->has($rel)) {
@@ -37,42 +32,28 @@ class HalLinks
         return $this->links[$rel];
     }
 
-    /**
-     * @param string $rel
-     *
-     * @return string
-     */
     public function getHref(string $rel): string
     {
         return $this->get($rel)->getHref();
     }
 
-    /**
-     * @param string $rel
-     * @param array  $params
-     *
-     * @return string
-     */
     public function expand(string $rel, array $params): string
     {
         return $this->get($rel)->expand($params);
     }
 
-    /**
-     * @param string $rel
-     *
-     * @return bool
-     */
     public function has(string $rel): bool
     {
         return array_key_exists($rel, $this->links);
     }
 
-    /**
-     * @param HalLink $link
-     */
     public function add(HalLink $link)
     {
         $this->links[$link->getRel()] = $link;
+    }
+
+    public function size(): int
+    {
+        return count($this->links);
     }
 }

--- a/tests/Conversations/Threads/ThreadTest.php
+++ b/tests/Conversations/Threads/ThreadTest.php
@@ -293,10 +293,12 @@ class ThreadTest extends TestCase
     {
         $thread = new Thread();
 
+        $this->assertFalse($thread->hasAttachments());
         $this->assertEmpty($thread->getAttachments());
 
         $attachment = new Attachment();
         $thread->addAttachment($attachment);
+        $this->assertTrue($thread->hasAttachments());
         $this->assertSame($attachment, $thread->getAttachments()->toArray()[0]);
     }
 }

--- a/tests/Http/Hal/HalDocumentTest.php
+++ b/tests/Http/Hal/HalDocumentTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Http\Hal;
 
 use HelpScout\Api\Exception\InvalidArgumentException;
+use HelpScout\Api\Http\Hal\HalDeserializer;
 use HelpScout\Api\Http\Hal\HalDocument;
+use HelpScout\Api\Http\Hal\HalLink;
 use HelpScout\Api\Http\Hal\HalLinks;
 use PHPUnit\Framework\TestCase;
 
@@ -56,10 +58,97 @@ class HalDocumentTest extends TestCase
         $this->assertEquals('London', $entities['address']['city']);
     }
 
+    public function testGetEmbeddedEntitiesMapsLinksWithMultipleEmbeddedEntities()
+    {
+        $emptyLinks = new HalLinks([]);
+        $thread = new HalDocument(
+            [],
+            $emptyLinks,
+            [
+                'attachments' => [
+                    new HalDocument(
+                        [
+                            'id' => 4823,
+                        ],
+                        new HalLinks([
+                            new HalLink('rel', 'href', true),
+                        ]),
+                        []
+                    ),
+                ],
+                'address' => new HalDocument(
+                    [
+                        'city' => 'London',
+                    ],
+                    $emptyLinks,
+                    []
+                ),
+            ]
+        );
+
+        $entities = $thread->getEmbeddedEntities();
+
+        // Asserts that a HasMany collection of embedded entities is mapped correctly
+        $this->assertArrayHasKey('attachments', $entities);
+        $this->assertEquals(4823, $entities['attachments'][0]['id']);
+
+        $this->assertArrayHasKey(HalDeserializer::LINKS, $entities['attachments'][0]);
+        $this->assertInstanceOf(HalLinks::class, $entities['attachments'][0][HalDeserializer::LINKS]);
+    }
+
+    public function testGetEmbeddedEntitiesMapsLinksWithSingleEmbeddedEntity()
+    {
+        $emptyLinks = new HalLinks([]);
+        $thread = new HalDocument(
+            [],
+            $emptyLinks,
+            [
+                'attachments' => [
+                    new HalDocument(
+                        [
+                            'id' => 4823,
+                        ],
+                        new HalLinks([
+                            new HalLink('rel', 'href', true),
+                        ]),
+                        []
+                    ),
+                ],
+            ]
+        );
+
+        $entities = $thread->getEmbeddedEntities();
+
+        // Asserts that a HasMany collection of embedded entities is mapped correctly
+        $this->assertArrayHasKey('attachments', $entities);
+        $this->assertEquals(4823, $entities['attachments'][0]['id']);
+
+        $this->assertArrayHasKey(HalDeserializer::LINKS, $entities['attachments'][0]);
+        $this->assertInstanceOf(HalLinks::class, $entities['attachments'][0][HalDeserializer::LINKS]);
+    }
+
     public function testGetEmbedKeysIsAlwaysAnArray()
     {
         $document = new HalDocument([], new HalLinks([]), []);
 
         $this->assertEquals([], $document->getEmbeddedEntities());
+    }
+
+    public function testDeterminesWhenLinksArePresent()
+    {
+        $documentWithoutLinks = new HalDocument([], new HalLinks([]), []);
+
+        $this->assertFalse($documentWithoutLinks->hasLinks());
+
+
+        $documentWithLinks = new HalDocument(
+            [],
+            new HalLinks([
+                new HalLink('rel', 'href', true),
+            ]),
+            []
+        );
+
+        $this->assertTrue($documentWithLinks->hasLinks());
     }
 }

--- a/tests/Http/Hal/HalDocumentTest.php
+++ b/tests/Http/Hal/HalDocumentTest.php
@@ -140,7 +140,6 @@ class HalDocumentTest extends TestCase
 
         $this->assertFalse($documentWithoutLinks->hasLinks());
 
-
         $documentWithLinks = new HalDocument(
             [],
             new HalLinks([

--- a/tests/Http/Hal/HalLinksTest.php
+++ b/tests/Http/Hal/HalLinksTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Http\Hal;
 
 use HelpScout\Api\Exception\InvalidArgumentException;
+use HelpScout\Api\Http\Hal\HalLink;
 use HelpScout\Api\Http\Hal\HalLinks;
 use PHPUnit\Framework\TestCase;
 
@@ -16,5 +17,14 @@ class HalLinksTest extends TestCase
 
         $links = new HalLinks();
         $links->get('unknown');
+    }
+
+    public function testCountsCollectionSize()
+    {
+        $this->assertFalse((new HalLinks())->size());
+
+        $links = new HalLinks();
+        $links->add(new HalLink('rel', 'href', false));
+        $this->assertFalse($links->size());
     }
 }

--- a/tests/Http/Hal/HalLinksTest.php
+++ b/tests/Http/Hal/HalLinksTest.php
@@ -21,10 +21,10 @@ class HalLinksTest extends TestCase
 
     public function testCountsCollectionSize()
     {
-        $this->assertFalse((new HalLinks())->size());
+        $this->assertEquals(0, (new HalLinks())->size());
 
         $links = new HalLinks();
         $links->add(new HalLink('rel', 'href', false));
-        $this->assertFalse($links->size());
+        $this->assertEquals(1, $links->size());
     }
 }


### PR DESCRIPTION
This PR adds the ability to obtain the URL for the attachment via `$attachment->getWebUrl()` which resolves https://github.com/helpscout/helpscout-api-php/issues/154.