### PR TITLE
Add type to thread response

### DIFF
--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -30,6 +30,11 @@ class Thread implements Extractable, Hydratable
     /**
      * @var string|null
      */
+    private $type;
+    
+    /**
+     * @var string|null
+     */
     private $status;
 
     /**
@@ -98,6 +103,7 @@ class Thread implements Extractable, Hydratable
             $this->setId((int) $data['id']);
         }
 
+        $this->type = $data['type'] ?? null;
         $this->status = $data['status'] ?? null;
         $this->state = $data['state'] ?? null;
 
@@ -166,6 +172,7 @@ class Thread implements Extractable, Hydratable
     {
         $data = [
             'id' => $this->getId(),
+            'type' => $this->getType(),
             'status' => $this->getStatus(),
             'state' => $this->getState(),
             'action' => null,
@@ -236,6 +243,11 @@ class Thread implements Extractable, Hydratable
         $this->id = $id;
 
         return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
     }
 
     public function getStatus(): ?string

--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -31,7 +31,7 @@ class Thread implements Extractable, Hydratable
      * @var string|null
      */
     private $type;
-    
+
     /**
      * @var string|null
      */

--- a/tests/Conversations/Threads/ThreadTest.php
+++ b/tests/Conversations/Threads/ThreadTest.php
@@ -19,7 +19,7 @@ class ThreadTest extends TestCase
     {
         $thread = new Thread();
         $thread->hydrate([
-            'id' => 12, 
+            'id' => 12,
             'type' => 'customer',
             'status' => 'active',
             'state' => 'published',

--- a/tests/Conversations/Threads/ThreadTest.php
+++ b/tests/Conversations/Threads/ThreadTest.php
@@ -19,7 +19,7 @@ class ThreadTest extends TestCase
     {
         $thread = new Thread();
         $thread->hydrate([
-            'id' => 12,
+            'id' => 12, 
             'type' => 'customer',
             'status' => 'active',
             'state' => 'published',
@@ -66,6 +66,7 @@ class ThreadTest extends TestCase
         ]);
 
         $this->assertSame(12, $thread->getId());
+        $this->assertSame('customer', $thread->getType());
         $this->assertSame('active', $thread->getStatus());
         $this->assertSame('published', $thread->getState());
         $this->assertSame('manual-workflow', $thread->getActionType());
@@ -163,6 +164,7 @@ class ThreadTest extends TestCase
         $thread = new Thread();
         $thread->hydrate([
             'id' => 12,
+            'type' => 'customer',
             'status' => 'active',
             'state' => 'published',
             'action' => [
@@ -204,6 +206,7 @@ class ThreadTest extends TestCase
 
         $this->assertEquals([
             'id' => 12,
+            'type' => 'customer',
             'status' => 'active',
             'state' => 'published',
             'action' => [
@@ -265,6 +268,7 @@ class ThreadTest extends TestCase
 
         $this->assertSame([
             'id' => null,
+            'type' => null,
             'status' => null,
             'state' => null,
             'action' => null,


### PR DESCRIPTION
The thread response was missing the 'type' property. We saw that you manage thread types with a number of extended thread classes, but noticed that on request the client just defaults to using the `Thread` class. So instead of working through how to conditionally assign the specific extended class depending on the type in the response we went with just adding the type property to the base Thread class.