### PR TITLE
Typed threads when being hydrated

### DIFF
--- a/examples/conversations.php
+++ b/examples/conversations.php
@@ -20,7 +20,7 @@ $conversation = $client->conversations()->get(12);
 
 // GET conversation with the threads
 $conversationRequest = new ConversationRequest();
-$conversationRequest->withThreads();
+$conversationRequest = $conversationRequest->withThreads();
 $conversation = $client->conversations()->get(12, $conversationRequest);
 
 // List conversations

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -771,6 +771,11 @@ class Conversation implements Extractable, Hydratable
     /**
      * Obtain the threads that were eagerly loaded when this conversation was obtained.
      *
+     * We will attempt to map the incoming Thread to a typed class.  The only threads
+     * we type are threads that can be created through the API (e.g. CustomerThread,
+     * NoteThread, etc.).  We do not type any kind of system threads such as a notice
+     * that a Workflow has run on a Conversation.
+     *
      * @see ConversationRequest
      *
      * @return Thread[]|Collection

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -10,6 +10,7 @@ use HelpScout\Api\Conversations\Threads\IncludesThreadDetails;
 use HelpScout\Api\Conversations\Threads\Support\HasCustomer;
 use HelpScout\Api\Conversations\Threads\Support\HasPartiesToBeNotified;
 use HelpScout\Api\Conversations\Threads\Thread;
+use HelpScout\Api\Conversations\Threads\ThreadFactory;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\Extractable;
@@ -181,9 +182,9 @@ class Conversation implements Extractable, Hydratable
                 $this->setThreadCount($data['threads']);
             } elseif (is_array($data['threads'])) {
                 $this->threads = new Collection();
+                $threadFactory = new ThreadFactory();
                 foreach ($data['threads'] as $threadData) {
-                    $thread = new Thread();
-                    $thread->hydrate($threadData);
+                    $thread = $threadFactory->make($threadData['type'], $threadData);
                     $this->threads->append($thread);
                 }
             }

--- a/src/Conversations/ConversationLoader.php
+++ b/src/Conversations/ConversationLoader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Conversations;
 
-use HelpScout\Api\Conversations\Threads\Thread;
+use HelpScout\Api\Conversations\Threads\ThreadFactory;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Entity\LinkedEntityLoader;
 use HelpScout\Api\Mailboxes\Mailbox;
@@ -43,7 +43,11 @@ class ConversationLoader extends LinkedEntityLoader
         }
 
         if ($this->shouldLoadResource(ConversationLinks::THREADS)) {
-            $threads = $this->loadResources(Thread::class, ConversationLinks::THREADS);
+            $threadFactory = new ThreadFactory();
+            $threads = $this->loadResources(function (array $data) use ($threadFactory) {
+                return $threadFactory->make($data['type'], $data);
+            }, ConversationLinks::THREADS);
+
             $conversation->setThreads($threads);
         }
 

--- a/src/Conversations/Threads/ChatThread.php
+++ b/src/Conversations/Threads/ChatThread.php
@@ -17,6 +17,11 @@ class ChatThread extends Thread
         return sprintf('/v2/conversations/%d/chats', $conversationId);
     }
 
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function hydrate(array $data, array $embedded = [])
     {
         parent::hydrate($data, $embedded);

--- a/src/Conversations/Threads/ChatThread.php
+++ b/src/Conversations/Threads/ChatThread.php
@@ -17,7 +17,7 @@ class ChatThread extends Thread
         return sprintf('/v2/conversations/%d/chats', $conversationId);
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return self::TYPE;
     }

--- a/src/Conversations/Threads/CustomerThread.php
+++ b/src/Conversations/Threads/CustomerThread.php
@@ -19,7 +19,7 @@ class CustomerThread extends Thread
         return sprintf('/v2/conversations/%d/customer', $conversationId);
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return self::TYPE;
     }

--- a/src/Conversations/Threads/CustomerThread.php
+++ b/src/Conversations/Threads/CustomerThread.php
@@ -19,6 +19,11 @@ class CustomerThread extends Thread
         return sprintf('/v2/conversations/%d/customer', $conversationId);
     }
 
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function hydrate(array $data, array $embedded = [])
     {
         parent::hydrate($data, $embedded);

--- a/src/Conversations/Threads/NoteThread.php
+++ b/src/Conversations/Threads/NoteThread.php
@@ -17,6 +17,11 @@ class NoteThread extends Thread
         return sprintf('/v2/conversations/%d/notes', $conversationId);
     }
 
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function extract(): array
     {
         $data = parent::extract();

--- a/src/Conversations/Threads/NoteThread.php
+++ b/src/Conversations/Threads/NoteThread.php
@@ -17,7 +17,7 @@ class NoteThread extends Thread
         return sprintf('/v2/conversations/%d/notes', $conversationId);
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return self::TYPE;
     }

--- a/src/Conversations/Threads/PhoneThread.php
+++ b/src/Conversations/Threads/PhoneThread.php
@@ -17,7 +17,7 @@ class PhoneThread extends Thread
         return sprintf('/v2/conversations/%d/phones', $conversationId);
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return self::TYPE;
     }

--- a/src/Conversations/Threads/PhoneThread.php
+++ b/src/Conversations/Threads/PhoneThread.php
@@ -12,6 +12,16 @@ class PhoneThread extends Thread
 
     use HasCustomer;
 
+    public static function resourceUrl(int $conversationId): string
+    {
+        return sprintf('/v2/conversations/%d/phones', $conversationId);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function hydrate(array $data, array $embedded = [])
     {
         parent::hydrate($data, $embedded);
@@ -19,11 +29,6 @@ class PhoneThread extends Thread
         if (isset($data['customer']) && is_array($data['customer'])) {
             $this->hydrateCustomer($data['customer']);
         }
-    }
-
-    public static function resourceUrl(int $conversationId): string
-    {
-        return sprintf('/v2/conversations/%d/phones', $conversationId);
     }
 
     public function extract(): array

--- a/src/Conversations/Threads/ReplyThread.php
+++ b/src/Conversations/Threads/ReplyThread.php
@@ -21,6 +21,11 @@ class ReplyThread extends Thread
         return sprintf('/v2/conversations/%d/reply', $conversationId);
     }
 
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     /**
      * @var bool
      */

--- a/src/Conversations/Threads/ReplyThread.php
+++ b/src/Conversations/Threads/ReplyThread.php
@@ -21,7 +21,7 @@ class ReplyThread extends Thread
         return sprintf('/v2/conversations/%d/reply', $conversationId);
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return self::TYPE;
     }

--- a/src/Conversations/Threads/ThreadFactory.php
+++ b/src/Conversations/Threads/ThreadFactory.php
@@ -15,6 +15,11 @@ class ThreadFactory
         '_default' => Thread::class,
     ];
 
+    /**
+     * Attempt to map the incoming Thread to a typed class.  The only threads we type
+     * are threads that can be created through the API.  We do not type any kind of
+     * system threads such as a notice that a Workflow has run on a Conversation.
+     */
     public function make(string $type, array $data): Thread
     {
         /** @var Thread $thread */

--- a/src/Entity/LinkedEntityLoader.php
+++ b/src/Entity/LinkedEntityLoader.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Entity;
 
+use Closure;
+use GuzzleHttp\Exception\GuzzleException;
+use HelpScout\Api\Exception\JsonException;
 use HelpScout\Api\Http\Hal\HalResource;
 use HelpScout\Api\Http\RestClient;
 
@@ -25,9 +28,9 @@ abstract class LinkedEntityLoader
     private $links;
 
     /**
-     * @param RestClient  $restClient
-     * @param HalResource $resource
-     * @param array       $links
+     * @param RestClient    $restClient
+     * @param HalResource   $resource
+     * @param array         $links
      */
     public function __construct(RestClient $restClient, HalResource $resource, array $links)
     {
@@ -44,12 +47,13 @@ abstract class LinkedEntityLoader
     }
 
     /**
-     * @param string $entityClass
-     * @param string $rel
+     * @param Closure|string    $entityClass
+     * @param string            $rel
      *
      * @return mixed
-     * @throws \HelpScout\Api\Exception\JsonException
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @throws JsonException
+     * @throws GuzzleException
      */
     protected function loadResource(string $entityClass, string $rel)
     {
@@ -59,12 +63,13 @@ abstract class LinkedEntityLoader
     }
 
     /**
-     * @param \Closure|string $entityClass
-     * @param string $rel
+     * @param Closure|string    $entityClass
+     * @param string            $rel
      *
      * @return Collection
-     * @throws \HelpScout\Api\Exception\JsonException
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @throws JsonException
+     * @throws GuzzleException
      */
     protected function loadResources($entityClass, string $rel): Collection
     {

--- a/src/Entity/LinkedEntityLoader.php
+++ b/src/Entity/LinkedEntityLoader.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace HelpScout\Api\Entity;
 
 use Closure;
-use GuzzleHttp\Exception\GuzzleException;
-use HelpScout\Api\Exception\JsonException;
 use HelpScout\Api\Http\Hal\HalResource;
 use HelpScout\Api\Http\RestClient;
 
@@ -28,9 +26,9 @@ abstract class LinkedEntityLoader
     private $links;
 
     /**
-     * @param RestClient    $restClient
-     * @param HalResource   $resource
-     * @param array         $links
+     * @param RestClient  $restClient
+     * @param HalResource $resource
+     * @param array       $links
      */
     public function __construct(RestClient $restClient, HalResource $resource, array $links)
     {
@@ -47,15 +45,12 @@ abstract class LinkedEntityLoader
     }
 
     /**
-     * @param Closure|string    $entityClass
-     * @param string            $rel
+     * @param Closure|string $entityClass
+     * @param string         $rel
      *
      * @return mixed
-     *
-     * @throws JsonException
-     * @throws GuzzleException
      */
-    protected function loadResource(string $entityClass, string $rel)
+    protected function loadResource($entityClass, string $rel)
     {
         $uri = $this->resource->getLinks()->getHref($rel);
 
@@ -63,13 +58,10 @@ abstract class LinkedEntityLoader
     }
 
     /**
-     * @param Closure|string    $entityClass
-     * @param string            $rel
+     * @param Closure|string $entityClass
+     * @param string         $rel
      *
      * @return Collection
-     *
-     * @throws JsonException
-     * @throws GuzzleException
      */
     protected function loadResources($entityClass, string $rel): Collection
     {

--- a/src/Entity/LinkedEntityLoader.php
+++ b/src/Entity/LinkedEntityLoader.php
@@ -48,6 +48,8 @@ abstract class LinkedEntityLoader
      * @param string $rel
      *
      * @return mixed
+     * @throws \HelpScout\Api\Exception\JsonException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     protected function loadResource(string $entityClass, string $rel)
     {
@@ -57,12 +59,14 @@ abstract class LinkedEntityLoader
     }
 
     /**
-     * @param string $entityClass
+     * @param \Closure|string $entityClass
      * @param string $rel
      *
      * @return Collection
+     * @throws \HelpScout\Api\Exception\JsonException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    protected function loadResources(string $entityClass, string $rel): Collection
+    protected function loadResources($entityClass, string $rel): Collection
     {
         $uri = $this->resource->getLinks()->getHref($rel);
         $resources = $this->restClient->getResources($entityClass, $rel, $uri);

--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -72,9 +72,10 @@ class RestClient
 
     /**
      * @param Extractable $entity
-     * @param string      $uri
+     * @param string $uri
      *
      * @return int|null
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function createResource(Extractable $entity, string $uri): ?int
     {
@@ -94,7 +95,8 @@ class RestClient
 
     /**
      * @param Extractable $entity
-     * @param string      $uri
+     * @param string $uri
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function updateResource(Extractable $entity, string $uri): void
     {
@@ -109,7 +111,8 @@ class RestClient
 
     /**
      * @param Extractable $entity
-     * @param string      $uri
+     * @param string $uri
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function patchResource(Extractable $entity, string $uri): void
     {
@@ -124,6 +127,7 @@ class RestClient
 
     /**
      * @param string $uri
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function deleteResource(string $uri): void
     {
@@ -137,9 +141,11 @@ class RestClient
 
     /**
      * @param \Closure|string $entityClass
-     * @param string          $uri
+     * @param string $uri
      *
      * @return HalResource
+     * @throws \HelpScout\Api\Exception\JsonException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function getResource($entityClass, string $uri): HalResource
     {
@@ -158,6 +164,8 @@ class RestClient
      * @param Report $report
      *
      * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \HelpScout\Api\Exception\JsonException
      */
     public function getReport(Report $report): array
     {
@@ -175,10 +183,12 @@ class RestClient
 
     /**
      * @param \Closure|string $entityClass
-     * @param string          $rel
-     * @param string          $uri
+     * @param string $rel
+     * @param string $uri
      *
      * @return HalResources
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \HelpScout\Api\Exception\JsonException
      */
     public function getResources($entityClass, string $rel, string $uri): HalResources
     {
@@ -207,6 +217,7 @@ class RestClient
      * @param Request $request
      *
      * @return mixed|ResponseInterface
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     private function send(Request $request)
     {

--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -6,11 +6,9 @@ namespace HelpScout\Api\Http;
 
 use Closure;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use HelpScout\Api\ApiClient;
 use HelpScout\Api\Entity\Extractable;
-use HelpScout\Api\Exception\JsonException;
 use HelpScout\Api\Http\Hal\HalDeserializer;
 use HelpScout\Api\Http\Hal\HalResource;
 use HelpScout\Api\Http\Hal\HalResources;
@@ -33,35 +31,22 @@ class RestClient
      */
     private $authenticator;
 
-    /**
-     * @param Client        $client
-     * @param Authenticator $authenticator
-     */
     public function __construct(Client $client, Authenticator $authenticator)
     {
         $this->client = $client;
         $this->authenticator = $authenticator;
     }
 
-    /**
-     * @return Authenticator
-     */
     public function getAuthenticator(): Authenticator
     {
         return $this->authenticator;
     }
 
-    /**
-     * @return array
-     */
     public function getAuthHeader(): array
     {
         return $this->authenticator->getAuthHeader();
     }
 
-    /**
-     * @return array
-     */
     public function getDefaultHeaders(): array
     {
         return array_merge(
@@ -73,14 +58,6 @@ class RestClient
         );
     }
 
-    /**
-     * @param Extractable $entity
-     * @param string $uri
-     *
-     * @return int|null
-     *
-     * @throws GuzzleException
-     */
     public function createResource(Extractable $entity, string $uri): ?int
     {
         $request = new Request(
@@ -97,12 +74,6 @@ class RestClient
             : null;
     }
 
-    /**
-     * @param Extractable $entity
-     * @param string $uri
-     *
-     * @throws GuzzleException
-     */
     public function updateResource(Extractable $entity, string $uri): void
     {
         $request = new Request(
@@ -114,12 +85,6 @@ class RestClient
         $this->send($request);
     }
 
-    /**
-     * @param Extractable $entity
-     * @param string $uri
-     *
-     * @throws GuzzleException
-     */
     public function patchResource(Extractable $entity, string $uri): void
     {
         $request = new Request(
@@ -131,11 +96,6 @@ class RestClient
         $this->send($request);
     }
 
-    /**
-     * @param string $uri
-     *
-     * @throws GuzzleException
-     */
     public function deleteResource(string $uri): void
     {
         $request = new Request(
@@ -148,12 +108,9 @@ class RestClient
 
     /**
      * @param Closure|string $entityClass
-     * @param string $uri
+     * @param string         $uri
      *
      * @return HalResource
-     *
-     * @throws JsonException
-     * @throws GuzzleException
      */
     public function getResource($entityClass, string $uri): HalResource
     {
@@ -168,14 +125,6 @@ class RestClient
         return HalDeserializer::deserializeResource($entityClass, $halDocument);
     }
 
-    /**
-     * @param Report $report
-     *
-     * @return array
-     *
-     * @throws GuzzleException
-     * @throws JsonException
-     */
     public function getReport(Report $report): array
     {
         $uri = $report->getUriPath();
@@ -192,12 +141,10 @@ class RestClient
 
     /**
      * @param Closure|string $entityClass
-     * @param string $rel
-     * @param string $uri
+     * @param string         $rel
+     * @param string         $uri
      *
      * @return HalResources
-     * @throws GuzzleException
-     * @throws JsonException
      */
     public function getResources($entityClass, string $rel, string $uri): HalResources
     {
@@ -212,11 +159,6 @@ class RestClient
         return HalDeserializer::deserializeResources($entityClass, $rel, $halDocument);
     }
 
-    /**
-     * @param Extractable $entity
-     *
-     * @return string
-     */
     private function encodeEntity(Extractable $entity): string
     {
         return json_encode($entity->extract());
@@ -226,7 +168,6 @@ class RestClient
      * @param Request $request
      *
      * @return mixed|ResponseInterface
-     * @throws GuzzleException
      */
     private function send(Request $request)
     {

--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Http;
 
+use Closure;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use HelpScout\Api\ApiClient;
 use HelpScout\Api\Entity\Extractable;
+use HelpScout\Api\Exception\JsonException;
 use HelpScout\Api\Http\Hal\HalDeserializer;
 use HelpScout\Api\Http\Hal\HalResource;
 use HelpScout\Api\Http\Hal\HalResources;
@@ -75,7 +78,8 @@ class RestClient
      * @param string $uri
      *
      * @return int|null
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @throws GuzzleException
      */
     public function createResource(Extractable $entity, string $uri): ?int
     {
@@ -96,7 +100,8 @@ class RestClient
     /**
      * @param Extractable $entity
      * @param string $uri
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @throws GuzzleException
      */
     public function updateResource(Extractable $entity, string $uri): void
     {
@@ -112,7 +117,8 @@ class RestClient
     /**
      * @param Extractable $entity
      * @param string $uri
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @throws GuzzleException
      */
     public function patchResource(Extractable $entity, string $uri): void
     {
@@ -127,7 +133,8 @@ class RestClient
 
     /**
      * @param string $uri
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @throws GuzzleException
      */
     public function deleteResource(string $uri): void
     {
@@ -140,12 +147,13 @@ class RestClient
     }
 
     /**
-     * @param \Closure|string $entityClass
+     * @param Closure|string $entityClass
      * @param string $uri
      *
      * @return HalResource
-     * @throws \HelpScout\Api\Exception\JsonException
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @throws JsonException
+     * @throws GuzzleException
      */
     public function getResource($entityClass, string $uri): HalResource
     {
@@ -164,8 +172,9 @@ class RestClient
      * @param Report $report
      *
      * @return array
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \HelpScout\Api\Exception\JsonException
+     *
+     * @throws GuzzleException
+     * @throws JsonException
      */
     public function getReport(Report $report): array
     {
@@ -182,13 +191,13 @@ class RestClient
     }
 
     /**
-     * @param \Closure|string $entityClass
+     * @param Closure|string $entityClass
      * @param string $rel
      * @param string $uri
      *
      * @return HalResources
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \HelpScout\Api\Exception\JsonException
+     * @throws GuzzleException
+     * @throws JsonException
      */
     public function getResources($entityClass, string $rel, string $uri): HalResources
     {
@@ -217,7 +226,7 @@ class RestClient
      * @param Request $request
      *
      * @return mixed|ResponseInterface
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws GuzzleException
      */
     private function send(Request $request)
     {

--- a/tests/Conversations/ConversationIntegrationTest.php
+++ b/tests/Conversations/ConversationIntegrationTest.php
@@ -9,7 +9,7 @@ use HelpScout\Api\Conversations\ConversationFilters;
 use HelpScout\Api\Conversations\ConversationRequest;
 use HelpScout\Api\Conversations\CustomField;
 use HelpScout\Api\Conversations\CustomFieldsCollection;
-use HelpScout\Api\Conversations\Threads\Thread;
+use HelpScout\Api\Conversations\Threads\CustomerThread;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Mailboxes\Mailbox;
@@ -221,7 +221,8 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
         $threads = $conversation->getThreads();
 
         $this->assertInstanceOf(Collection::class, $threads);
-        $this->assertInstanceOf(Thread::class, $threads[0]);
+
+        $this->assertInstanceOf(CustomerThread::class, $threads[0]);
 
         $this->verifyMultipleRequests([
             ['GET', 'https://api.helpscout.net/v2/conversations/1'],

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -14,6 +14,7 @@ use HelpScout\Api\Conversations\EmailConversation;
 use HelpScout\Api\Conversations\PhoneConversation;
 use HelpScout\Api\Conversations\Status;
 use HelpScout\Api\Conversations\Threads\ChatThread;
+use HelpScout\Api\Conversations\Threads\CustomerThread;
 use HelpScout\Api\Conversations\Threads\Thread;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Customers\Entry\Email;
@@ -543,6 +544,7 @@ EOF;
         $this->assertSame(179783313, $conversation->getCustomer()->getId());
 
         $thread = $conversation->getThreads()[0];
+        $this->assertInstanceOf(CustomerThread::class, $thread);
         $this->assertSame(2198262392, $thread->getId());
 
         $tag = $conversation->getTags()[0];

--- a/tests/Conversations/Threads/ChatThreadTest.php
+++ b/tests/Conversations/Threads/ChatThreadTest.php
@@ -14,6 +14,7 @@ class ChatThreadTest extends TestCase
     public function testHasExpectedType()
     {
         $this->assertEquals('chat', ChatThread::TYPE);
+        $this->assertEquals('chat', (new ChatThread())->getType());
     }
 
     public function testExtractsType()

--- a/tests/Conversations/Threads/CustomerThreadTest.php
+++ b/tests/Conversations/Threads/CustomerThreadTest.php
@@ -15,6 +15,7 @@ class CustomerThreadTest extends TestCase
     public function testHasExpectedType()
     {
         $this->assertEquals('customer', CustomerThread::TYPE);
+        $this->assertEquals('customer', (new CustomerThread())->getType());
     }
 
     public function testExtractsType()

--- a/tests/Conversations/Threads/NoteThreadTest.php
+++ b/tests/Conversations/Threads/NoteThreadTest.php
@@ -14,6 +14,7 @@ class NoteThreadTest extends TestCase
     public function testHasExpectedType()
     {
         $this->assertEquals('note', NoteThread::TYPE);
+        $this->assertEquals('note', (new NoteThread())->getType());
     }
 
     public function testExtractsType()

--- a/tests/Conversations/Threads/PhoneThreadTest.php
+++ b/tests/Conversations/Threads/PhoneThreadTest.php
@@ -14,6 +14,7 @@ class PhoneThreadTest extends TestCase
     public function testHasExpectedType()
     {
         $this->assertEquals('phone', PhoneThread::TYPE);
+        $this->assertEquals('phone', (new PhoneThread())->getType());
     }
 
     public function testExtractsType()

--- a/tests/Conversations/Threads/ReplyThreadTest.php
+++ b/tests/Conversations/Threads/ReplyThreadTest.php
@@ -13,6 +13,7 @@ class ReplyThreadTest extends TestCase
     public function testHasExpectedType()
     {
         $this->assertEquals('reply', ReplyThread::TYPE);
+        $this->assertEquals('reply', (new ReplyThread())->getType());
     }
 
     public function testExtractsType()


### PR DESCRIPTION
When hydrating a Conversation's threads, we are now casting them to an object that represents their type.  The factory in use already has a fallback to use `Thread` for unrecognized thread types.

This is a follow up PR To https://github.com/helpscout/helpscout-api-php/pull/159.