### PR TITLE
New shorthand syntax for adding a single email to a Customer

### DIFF
--- a/examples/customers.php
+++ b/examples/customers.php
@@ -14,10 +14,7 @@ $client = $client->useClientCredentials($appId, $appSecret);
 $customer = new Customer();
 $customer->setFirstName('John');
 $customer->setLastName('Smith');
-$customer->addEmail(new Email([
-    'email' => "my-customer@their-business.com",
-    'type' => 'work',
-]));
+$customer->addEmail("my-customer@their-busines2s.com", 'work');
 $client->customers()->create($customer);
 
 // GET customers

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -604,8 +604,21 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    public function addEmail(Email $email): Customer
+    /**
+     * @param Email|string $email
+     * @param string       $type
+     */
+    public function addEmail($email, string $type = null): Customer
     {
+        if (is_string($email)) {
+            $newEmail = new Email();
+            $newEmail->hydrate([
+                'value' => $email,
+                'type' => $type,
+            ]);
+            $email = $newEmail;
+        }
+
         $this->getEmails()->append($email);
 
         return $this;

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -122,6 +122,18 @@ class CustomerTest extends TestCase
         $this->assertSame(798, $emails[1]->getId());
     }
 
+    public function testAddEmailShortSyntax()
+    {
+        $customer = new Customer();
+        $customer->addEmail('test@test.com', 'work');
+
+        $emails = $customer->getEmails();
+
+        $this->assertInstanceOf(Email::class, $emails[0]);
+        $this->assertSame('test@test.com', $emails[0]->getValue());
+        $this->assertSame('work', $emails[0]->getType());
+    }
+
     public function testHydratesManySocialProfiles()
     {
         $customer = new Customer();


### PR DESCRIPTION
`$customer->addEmail()` will now build an `Email` if passed 2 strings.