### PR TITLE
Creating a Conversation for a User

### DIFF
--- a/examples/conversations.php
+++ b/examples/conversations.php
@@ -8,6 +8,7 @@ use HelpScout\Api\Conversations\ConversationFilters;
 use HelpScout\Api\Conversations\ConversationRequest;
 use HelpScout\Api\Conversations\CustomField;
 use HelpScout\Api\Conversations\Threads\ChatThread;
+use HelpScout\Api\Conversations\Threads\PhoneThread;
 use HelpScout\Api\Tags\Tag;
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Entity\Collection;
@@ -44,26 +45,53 @@ $filters = (new ConversationFilters())
 
 $conversations = $client->conversations()->list($filters);
 
-// Create conversation
+/**
+ * Create Conversation: Chat thread, initiated by the Customer
+ */
 $noteCustomer = new Customer();
 $noteCustomer->setId(163315601);
 $thread = new ChatThread();
 $thread->setCustomer($noteCustomer);
 $thread->setText('Test');
-$tag = new Tag();
-$tag->setName('testing');
-
 $conversation = new Conversation();
-$conversation->setSubject('Testing the PHP SDK v2');
+$conversation->setSubject('Testing the PHP SDK v2: Chat Thread');
 $conversation->setStatus('active');
-$conversation->setType('email');
+$conversation->setType('chat');
 $conversation->setAssignTo(271315);
 $conversation->setMailboxId(138367);
 $conversation->setCustomer($noteCustomer);
 $conversation->setThreads(new Collection([
     $thread,
 ]));
+
+// Also adding a tag to this conversation
+$tag = new Tag();
+$tag->setName('testing');
 $conversation->addTag($tag);
+
+$conversationId = $client->conversations()->create($conversation);
+
+/**
+ * Create Conversation: Phone thread, initiated by a Help Scout user
+ */
+$user = $client->users()->get(64235);
+$noteCustomer = new Customer();
+$noteCustomer->setId(193338443); // Customer
+$thread = new PhoneThread();
+$thread->setCustomer($noteCustomer);
+$thread->setCreatedByUser($user);
+$thread->setText('Test');
+
+$conversation = new Conversation();
+$conversation->setSubject('Testing the PHP SDK v2: Phone Thread');
+$conversation->setStatus('active');
+$conversation->setType('phone');
+$conversation->setMailboxId(80261);
+$conversation->setCustomer($noteCustomer);
+$conversation->setCreatedByUser($user);
+$conversation->setThreads(new Collection([
+    $thread,
+]));
 
 $conversationId = $client->conversations()->create($conversation);
 

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -368,10 +368,13 @@ class Conversation implements Extractable, Hydratable
                 'type' => 'customer',
             ];
         } elseif ($this->wasCreatedByUser()) {
+            // Maintaining consistency with hydrate() so we don't incur data loss during the extract/hydrate chain
             $data['createdBy'] = [
                 'id' => $this->getCreatedByUser()->getId(),
                 'type' => 'user',
             ];
+            // Api wants this to be the user id when creating conversations
+            $data['user'] = $this->getCreatedByUser()->getId();
         }
 
         if (count($this->getCustomFields()) > 0) {

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -161,6 +161,10 @@ class ConversationTest extends TestCase
             'id' => 9865,
             'type' => 'user',
         ], $extracted['createdBy']);
+
+        // Used by the api when creating new conversations
+        $this->assertArrayHasKey('user', $extracted);
+        $this->assertEquals(9865, $extracted['user']);
     }
 
     public function testExtract()


### PR DESCRIPTION
This PR resolves https://github.com/helpscout/helpscout-api-php/issues/163.

Changes include:

 * An additional example of how to create a conversation on behalf of another user
 * When extracting a Conversation, `user` is now the created by id for the user