### PR TITLE
Added shorthand methods for all customer entries

### DIFF
--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -698,8 +698,8 @@ class Customer implements Extractable, Hydratable
     }
 
     /**
-     * @param Phone|string $phone
-     * @param string       $type
+     * @param SocialProfile|string $phone
+     * @param string               $type
      */
     public function addSocialProfile($profile, string $type = null): Customer
     {

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -531,7 +531,7 @@ class Customer implements Extractable, Hydratable
     }
 
     /**
-     * @param ChatHandle|string $chatHandle
+     * @param ChatHandle|string $chat
      * @param string            $type
      */
     public function addChatHandle($chat, string $type = null): Customer
@@ -698,7 +698,7 @@ class Customer implements Extractable, Hydratable
     }
 
     /**
-     * @param SocialProfile|string $phone
+     * @param SocialProfile|string $profile
      * @param string               $type
      */
     public function addSocialProfile($profile, string $type = null): Customer
@@ -739,7 +739,6 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Website|string $website
-     * @param string         $type
      */
     public function addWebsite($website): Customer
     {

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -530,8 +530,21 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    public function addChatHandle(ChatHandle $chat): Customer
+    /**
+     * @param ChatHandle|string $chatHandle
+     * @param string            $type
+     */
+    public function addChatHandle($chat, string $type = null): Customer
     {
+        if (is_string($chat)) {
+            $newChatHandle = new ChatHandle();
+            $newChatHandle->hydrate([
+                'value' => $chat,
+                'type' => $type,
+            ]);
+            $chat = $newChatHandle;
+        }
+
         $this->getChatHandles()->append($chat);
 
         return $this;
@@ -644,8 +657,21 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    public function addPhone(Phone $phone): Customer
+    /**
+     * @param Phone|string $phone
+     * @param string       $type
+     */
+    public function addPhone($phone, string $type = null): Customer
     {
+        if (is_string($phone)) {
+            $newPhone = new Phone();
+            $newPhone->hydrate([
+                'value' => $phone,
+                'type' => $type,
+            ]);
+            $phone = $newPhone;
+        }
+
         $this->getPhones()->append($phone);
 
         return $this;
@@ -671,8 +697,21 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    public function addSocialProfile(SocialProfile $profile): Customer
+    /**
+     * @param Phone|string $phone
+     * @param string       $type
+     */
+    public function addSocialProfile($profile, string $type = null): Customer
     {
+        if (is_string($profile)) {
+            $newProfile = new SocialProfile();
+            $newProfile->hydrate([
+                'value' => $profile,
+                'type' => $type,
+            ]);
+            $profile = $newProfile;
+        }
+
         $this->getSocialProfiles()->append($profile);
 
         return $this;
@@ -698,8 +737,20 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    public function addWebsite(Website $website): Customer
+    /**
+     * @param Website|string $website
+     * @param string         $type
+     */
+    public function addWebsite($website): Customer
     {
+        if (is_string($website)) {
+            $newWebsite = new Website();
+            $newWebsite->hydrate([
+                'value' => $website,
+            ]);
+            $website = $newWebsite;
+        }
+
         $this->getWebsites()->append($website);
 
         return $this;

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -339,7 +339,6 @@ class CustomerTest extends TestCase
         $this->assertSame('aim', $chatHandles[0]->getType());
     }
 
-
     public function testExtractChatHandles()
     {
         $customer = new Customer();

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -327,6 +327,19 @@ class CustomerTest extends TestCase
         $this->assertSame($chat, $customer->getChatHandles()->toArray()[0]);
     }
 
+    public function testAddChatHandleShortSyntax()
+    {
+        $customer = new Customer();
+        $customer->addChatHandle('helpscout', 'aim');
+
+        $chatHandles = $customer->getChatHandles();
+
+        $this->assertInstanceOf(ChatHandle::class, $chatHandles[0]);
+        $this->assertSame('helpscout', $chatHandles[0]->getValue());
+        $this->assertSame('aim', $chatHandles[0]->getType());
+    }
+
+
     public function testExtractChatHandles()
     {
         $customer = new Customer();
@@ -371,6 +384,17 @@ class CustomerTest extends TestCase
         $this->assertSame($phone, $customer->getPhones()->toArray()[0]);
     }
 
+    public function testAddPhoneShortSyntax()
+    {
+        $customer = new Customer();
+        $customer->addPhone('14235554837');
+
+        $phones = $customer->getPhones();
+
+        $this->assertInstanceOf(Phone::class, $phones[0]);
+        $this->assertSame('14235554837', $phones[0]->getValue());
+    }
+
     public function testExtractPhones()
     {
         $customer = new Customer();
@@ -393,6 +417,18 @@ class CustomerTest extends TestCase
         $this->assertSame($profile, $customer->getSocialProfiles()->toArray()[0]);
     }
 
+    public function testAddSocialProfileShortSyntax()
+    {
+        $customer = new Customer();
+        $customer->addSocialProfile('helpscout', 'twitter');
+
+        $socialProfiles = $customer->getSocialProfiles();
+
+        $this->assertInstanceOf(SocialProfile::class, $socialProfiles[0]);
+        $this->assertSame('helpscout', $socialProfiles[0]->getValue());
+        $this->assertSame('twitter', $socialProfiles[0]->getType());
+    }
+
     public function testExtractSocialProfiles()
     {
         $customer = new Customer();
@@ -413,6 +449,17 @@ class CustomerTest extends TestCase
         $website = new Website();
         $customer->addWebsite($website);
         $this->assertSame($website, $customer->getWebsites()->toArray()[0]);
+    }
+
+    public function testAddWebsiteShortSyntax()
+    {
+        $customer = new Customer();
+        $customer->addWebsite('http://helpscout.com');
+
+        $website = $customer->getWebsites();
+
+        $this->assertInstanceOf(Website::class, $website[0]);
+        $this->assertSame('http://helpscout.com', $website[0]->getValue());
     }
 
     public function testExtractWebsites()


### PR DESCRIPTION
I previously submitted a PR to enable `addEmail()` to accept an `Email` or a few strings and it would build an object.  This expands that functionality to other Customer entries as well, fulfilling the request in https://github.com/helpscout/helpscout-api-php/issues/164#issuecomment-501933300.