### PR TITLE
Support _embedded returning a single resource object

### DIFF
--- a/src/Http/Hal/HalDeserializer.php
+++ b/src/Http/Hal/HalDeserializer.php
@@ -57,9 +57,13 @@ class HalDeserializer
     public static function deserializeResources($entityClass, string $rel, HalDocument $halDocument): HalResources
     {
         if ($halDocument->hasEmbedded($rel)) {
+            $embedded = $halDocument->getEmbedded($rel);
+            if (!is_array($embedded)) {
+                $embedded = [$embedded];
+            }
             $resources = array_map(function (HalDocument $embeddedDocument) use ($entityClass) {
                 return self::deserializeResource($entityClass, $embeddedDocument);
-            }, $halDocument->getEmbedded($rel));
+            }, $embedded);
         } else {
             $resources = [];
         }

--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -46,7 +46,8 @@ class HalDocument
     }
 
     /**
-     * @param  string  $rel
+     * @param string $rel
+     *
      * @return HalDocument|HalDocument[]
      */
     public function getEmbedded(string $rel)

--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -45,7 +45,11 @@ class HalDocument
         return $this->links->size() > 0;
     }
 
-    public function getEmbedded(string $rel): array
+    /**
+     * @param  string  $rel
+     * @return HalDocument|HalDocument[]
+     */
+    public function getEmbedded(string $rel)
     {
         if (!$this->hasEmbedded($rel)) {
             throw new InvalidArgumentException(sprintf('The embedded resource "%s" was not found', $rel));

--- a/tests/Http/Hal/HalDeserializerTest.php
+++ b/tests/Http/Hal/HalDeserializerTest.php
@@ -36,6 +36,7 @@ class HalDeserializerTest extends TestCase
 
         $this->assertInstanceOf(HalDocument::class, $halDocument);
         $this->assertTrue($halDocument->hasEmbedded('address'));
+        $this->assertInstanceOf(HalDocument::class, $halDocument->getEmbedded('address'));
     }
 
     public function testDeserializeDocumentWithEmptyCollection()


### PR DESCRIPTION
According to the [HAL specification](https://tools.ietf.org/html/draft-kelly-json-hal-08#section-4.1.2) `_embedded` can contain "either a Resource Object or an array of Resource Objects."

As explained in #175 the Mailbox V2 API was recently updated to return a single resource from the customers endpoint when filtering. Since the `HalDeserializer` only supports arrays of embedded resources this caused a fatal error.

There aren't any tests for `HalDeserializer::deserializeResources` yet so the changes in that method don't have any test coverage yet.