### PR TITLE
Fix embedded single entity return

### DIFF
--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -51,7 +51,12 @@ class HalDocument
             throw new InvalidArgumentException(sprintf('The embedded resource "%s" was not found', $rel));
         }
 
-        return $this->embedded[$rel];
+        $embedded = $this->embedded[$rel];
+
+        if (!is_array($embedded)) {
+            $embedded = [$embedded];
+        }
+        return $embedded;
     }
 
     /**

--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -50,12 +50,11 @@ class HalDocument
         if (!$this->hasEmbedded($rel)) {
             throw new InvalidArgumentException(sprintf('The embedded resource "%s" was not found', $rel));
         }
-
         $embedded = $this->embedded[$rel];
-
         if (!is_array($embedded)) {
             $embedded = [$embedded];
         }
+
         return $embedded;
     }
 

--- a/tests/Http/Hal/HalDocumentTest.php
+++ b/tests/Http/Hal/HalDocumentTest.php
@@ -150,4 +150,23 @@ class HalDocumentTest extends TestCase
 
         $this->assertTrue($documentWithLinks->hasLinks());
     }
+
+    public function testGetEmbeddedAlwaysReturnsArray()
+    {
+        $document = new HalDocument(
+            [],
+            new HalLinks([]),
+            [
+                'customers' => new HalDocument(
+                    [
+                    ],
+                    new HalLinks([
+                    ]),
+                    []
+                ),
+            ]
+        );
+        $embedded = $document->getEmbedded('customers');
+        $this->assertTrue(is_array($embedded));
+    }
 }


### PR DESCRIPTION
An issue was raised [here](https://github.com/helpscout/helpscout-api-php/issues/175) that we were throwing fatal errors specifically
```
Uncaught TypeError: Return value of HelpScout\Api\Http\Hal\HalDocument::getEmbedded() must be of the type array, object returned in /home/matt/code/helpscout-api-php/src/Http/Hal/HalDocument.php:54
```

This is due to a recent change in the API where empty list endpoints were previously not returning the `_embeddable.customers` array and now they are, `{"_embedded" : { "customers" : [] }}` This caused our `getEmbedded` function to return a single Document instead of an array. 

To fix this we have chosen to ensure that we always return an array to ensure the previous behavior is kept. 