### PR TITLE
No longer hydrating empty embedded objects

### DIFF
--- a/src/Http/Hal/HalDeserializer.php
+++ b/src/Http/Hal/HalDeserializer.php
@@ -57,13 +57,9 @@ class HalDeserializer
     public static function deserializeResources($entityClass, string $rel, HalDocument $halDocument): HalResources
     {
         if ($halDocument->hasEmbedded($rel)) {
-            $embedded = $halDocument->getEmbedded($rel);
-            if (!is_array($embedded)) {
-                $embedded = [$embedded];
-            }
             $resources = array_map(function (HalDocument $embeddedDocument) use ($entityClass) {
                 return self::deserializeResource($entityClass, $embeddedDocument);
-            }, $embedded);
+            }, $halDocument->getEmbedded($rel));
         } else {
             $resources = [];
         }

--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -46,8 +46,6 @@ class HalDocument
     }
 
     /**
-     * @param string $rel
-     *
      * @return HalDocument|HalDocument[]
      */
     public function getEmbedded(string $rel)
@@ -99,6 +97,13 @@ class HalDocument
 
     public function hasEmbedded(string $rel): bool
     {
-        return array_key_exists($rel, $this->embedded);
+        // The embedded array key may be present, but we also need to verify that it has contents, since it may not
+        return array_key_exists($rel, $this->embedded) && (
+            // An embedded entity may be a single item
+            $this->embedded[$rel] instanceof HalDocument ||
+
+            // It also may be a collection of HalDocuments
+            (is_array($this->embedded[$rel]) && count($this->embedded[$rel]) > 0)
+        );
     }
 }

--- a/tests/Http/Hal/HalDocumentTest.php
+++ b/tests/Http/Hal/HalDocumentTest.php
@@ -150,4 +150,35 @@ class HalDocumentTest extends TestCase
 
         $this->assertTrue($documentWithLinks->hasLinks());
     }
+
+    public function testContainsEmbeddedWhenContainsContent()
+    {
+        $customer = new HalDocument([
+            'name' => 'Clark',
+        ], new HalLinks(), []);
+
+        $conversation = new HalDocument([
+            'id' => 1458,
+        ], new HalLinks(), []);
+
+        $documentWithoutLinks = new HalDocument([], new HalLinks([]), [
+            'customer' => $customer,
+            'conversations' => [
+                $conversation,
+            ],
+        ]);
+
+        $this->assertTrue($documentWithoutLinks->hasEmbedded('customer'));
+        $this->assertTrue($documentWithoutLinks->hasEmbedded('conversations'));
+    }
+
+    public function testDoesntContainEmbeddedWhenContentsAreEmpty()
+    {
+        $documentWithoutLinks = new HalDocument([], new HalLinks([]), [
+            'customers' => [],
+        ]);
+
+        $this->assertFalse($documentWithoutLinks->hasEmbedded('conversations'));
+        $this->assertFalse($documentWithoutLinks->hasEmbedded('customers'));
+    }
 }


### PR DESCRIPTION
## Problem

In PR https://github.com/helpscout/helpscout-api-php/pull/176 we included a change that fixed an issue that was unintentionally introduced with a [minor change to our API](https://github.com/helpscout/helpscout-api-php/issues/175#issuecomment-512028031).  While that fixed the issue we were seeing, it introduced another issue where when [empty collections were expected we were hydrating a single empty object](https://github.com/helpscout/helpscout-api-php/issues/178).

## Solution

This reverts the solution implemented in https://github.com/helpscout/helpscout-api-php/pull/176 (leaving the test in place) and solves the problem differently by not hydrating anything at all if the collection is empty.