### PR TITLE
Correlation id alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,9 +938,9 @@ try {
     $error = $e->getError();
 
     var_dump(
-        // A reference id for that request.  Including this anytime you contact Help Scout support will enable
-        // us to help you much more quickly
-        $error->getLogRef(),
+        // A reference id for that request.  Including this anytime you contact Help Scout will
+        // empower us to dig right to the heart of the issue
+        $error->getCorrelationId(),
 
         // Details about the invalid fields in the request
         $error->getErrors()

--- a/src/Http/Hal/VndError.php
+++ b/src/Http/Hal/VndError.php
@@ -58,6 +58,17 @@ class VndError
     }
 
     /**
+     * Alias of getLogRef.  Internally we use the term correlationId so using this in the SDK will help developers
+     * understand what we're asking for when we ask for this.
+     *
+     * @return string|null
+     */
+    public function getCorrelationId()
+    {
+        return $this->getLogRef();
+    }
+
+    /**
      * @return string|null
      */
     public function getPath()

--- a/tests/Http/Hal/HalDeserializerTest.php
+++ b/tests/Http/Hal/HalDeserializerTest.php
@@ -64,7 +64,9 @@ class HalDeserializerTest extends TestCase
 
         $this->assertInstanceOf(VndError::class, $error);
         $this->assertSame('Validation error', $error->getMessage());
-        $this->assertSame('cb73aad3-9a81-44fd-bf70-48250ea256ff#12', $error->getLogRef());
+        $correlationId = 'cb73aad3-9a81-44fd-bf70-48250ea256ff#12';
+        $this->assertSame($correlationId, $error->getLogRef());
+        $this->assertSame($correlationId, $error->getCorrelationId());
         $this->assertNull($error->getPath());
 
         $errors = $error->getErrors();
@@ -82,7 +84,9 @@ class HalDeserializerTest extends TestCase
 
         $this->assertInstanceOf(VndError::class, $error);
         $this->assertSame('Internal error', $error->getMessage());
-        $this->assertSame('cb73aad3-9a81-44fd-bf70-48250ea256ff#12', $error->getLogRef());
+        $correlationId = 'cb73aad3-9a81-44fd-bf70-48250ea256ff#12';
+        $this->assertSame($correlationId, $error->getLogRef());
+        $this->assertSame($correlationId, $error->getCorrelationId());
         $this->assertNull($error->getPath());
         $this->assertCount(0, $error->getErrors());
     }


### PR DESCRIPTION
## Problem

When contacting us about issues we may ask for a "correlation id" since that's the term we use internally.  It isn't clear in the SDK where/how to obtain this.

## Solution

Adding `getCorrelationId()` as an alias for `getLogRef()` so it's more clear what we're asking for.