### PR TITLE
More clear direction on how to handle validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,11 @@ $customer = new Customer();
 $customer->setFirstName('Bob');
 // ...
 
-$client->customers()->create($customer);
+try {
+    $customerId = $client->customers()->create($customer);
+} catch (\HelpScout\Api\Exception\ValidationErrorException $e) {
+    var_dump($e->getError()->getErrors());
+}
 ```
 
 Update a customer.

--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -8,6 +8,7 @@ use HelpScout\Api\Endpoint;
 use HelpScout\Api\Entity\Collection;
 use HelpScout\Api\Entity\PagedCollection;
 use HelpScout\Api\Entity\Patch;
+use HelpScout\Api\Exception\ValidationErrorException;
 use HelpScout\Api\Http\Hal\HalPagedResources;
 use HelpScout\Api\Http\Hal\HalResource;
 use HelpScout\Api\Tags\TagsCollection;
@@ -38,6 +39,8 @@ class ConversationsEndpoint extends Endpoint
     /**
      * @param Conversation $conversation
      *
+     * @throws ValidationErrorException
+     *
      * @return int|null
      */
     public function create(Conversation $conversation): ?int
@@ -50,6 +53,8 @@ class ConversationsEndpoint extends Endpoint
      *
      * @param int                                                   $conversationId
      * @param CustomField[]|array|Collection|CustomFieldsCollection $customFields
+     *
+     * @throws ValidationErrorException
      */
     public function updateCustomFields(int $conversationId, $customFields): void
     {
@@ -76,6 +81,8 @@ class ConversationsEndpoint extends Endpoint
      *
      * @param int                             $conversationId
      * @param array|Collection|TagsCollection $tags
+     *
+     * @throws ValidationErrorException
      */
     public function updateTags(int $conversationId, $tags): void
     {
@@ -181,6 +188,8 @@ class ConversationsEndpoint extends Endpoint
      *
      * @param int    $conversationId
      * @param string $subject
+     *
+     * @throws ValidationErrorException
      */
     public function updateSubject(int $conversationId, string $subject): void
     {
@@ -193,6 +202,8 @@ class ConversationsEndpoint extends Endpoint
      *
      * @param int $conversationId
      * @param int $newCustomerId
+     *
+     * @throws ValidationErrorException
      */
     public function updateCustomer(int $conversationId, int $newCustomerId): void
     {
@@ -212,6 +223,8 @@ class ConversationsEndpoint extends Endpoint
     /**
      * @param int    $conversationId
      * @param string $status
+     *
+     * @throws ValidationErrorException
      */
     public function updateStatus(int $conversationId, string $status): void
     {

--- a/src/Customers/CustomersEndpoint.php
+++ b/src/Customers/CustomersEndpoint.php
@@ -6,6 +6,7 @@ namespace HelpScout\Api\Customers;
 
 use HelpScout\Api\Endpoint;
 use HelpScout\Api\Entity\PagedCollection;
+use HelpScout\Api\Exception\ValidationErrorException;
 use HelpScout\Api\Http\Hal\HalPagedResources;
 use HelpScout\Api\Http\Hal\HalResource;
 
@@ -13,6 +14,8 @@ class CustomersEndpoint extends Endpoint
 {
     /**
      * @param Customer $customer
+     *
+     * @throws ValidationErrorException
      *
      * @return int|null
      */
@@ -26,6 +29,8 @@ class CustomersEndpoint extends Endpoint
 
     /**
      * @param Customer $customer
+     *
+     * @throws ValidationErrorException
      */
     public function update(Customer $customer): void
     {

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -30,6 +30,9 @@ class ValidationErrorException extends RequestException implements Exception
         ResponseInterface $response,
         \Exception $previous = null
     ) {
+        // Append some details on what steps to take to see the underlying validation problems are.
+        $message = $message.' - use getError() to see the underlying validation issues ';
+
         parent::__construct($message, $request, $response, $previous);
 
         $this->error = $error;

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -31,7 +31,7 @@ class ValidationErrorException extends RequestException implements Exception
         \Exception $previous = null
     ) {
         // Append some details on what steps to take to see the underlying validation problems are.
-        $message = $message.' - use getError() to see the underlying validation issues ';
+        $message = $message.' - use getError() to see the underlying validation issues';
 
         parent::__construct($message, $request, $response, $previous);
 


### PR DESCRIPTION
## Problem
Sometimes it's not clear to developers that they can catch a validation exception to see the validation errors they're encountering.  When this happens, they end up needing to contact us to figure out what the underlying problem is.

## Solution
 * Added `@throws` tags for endpoints so IDEs are aware when there are unhandled exceptions
 * Added try/catch block to the creating Customers example
 * Added directions on how to expose validation errors in the exception message itself so it's more clear what to do when it's seen in logs or CLI output:

![Screen Shot 2019-07-30 at 10 30 14 AM](https://user-images.githubusercontent.com/524933/62138904-7815d700-b2b6-11e9-9cf5-af68a1ea9a66.png)
