### PR TITLE
Fixed formatting datetime for send to API

### DIFF
--- a/src/Conversations/ConversationFilters.php
+++ b/src/Conversations/ConversationFilters.php
@@ -76,7 +76,7 @@ class ConversationFilters
             'status' => $this->status,
             'assigned_to' => $this->assignedTo,
             'number' => $this->number,
-            'modifiedSince' => $this->modifiedSince !== null ? $this->modifiedSince->format('c') : null,
+            'modifiedSince' => $this->modifiedSince !== null ? $this->modifiedSince->format('Y-m-d\TH:i:s\Z') : null,
             'sortField' => $this->sortField,
             'sortOrder' => $this->sortOrder,
             'query' => $this->query,

--- a/tests/Conversations/ConversationFiltersTest.php
+++ b/tests/Conversations/ConversationFiltersTest.php
@@ -40,7 +40,7 @@ class ConversationFiltersTest extends TestCase
             'status' => 'all',
             'assigned_to' => 1771,
             'number' => 42,
-            'modifiedSince' => '2017-05-06T04:04:23+00:00',
+            'modifiedSince' => '2017-05-06T04:04:23Z',
             'sortField' => 'createdAt',
             'sortOrder' => 'asc',
             'query' => 'query',


### PR DESCRIPTION
Hello,

when is send datetime to API with full ISO format like as `2004-02-12T15:19:21+00:00` so API return error:

```
Bad request
Invalid date - expected ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') 
```

PR fixed this bug with manual format datetimes. I tried it with production HelpScout API