### PR TITLE
Update date format

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -18,6 +18,7 @@ use HelpScout\Api\Tags\TagsEndpoint;
 use HelpScout\Api\Users\UsersEndpoint;
 use HelpScout\Api\Webhooks\WebhooksEndpoint;
 use HelpScout\Api\Workflows\WorkflowsEndpoint;
+use Mockery\LegacyMockInterface;
 
 class ApiClient
 {
@@ -57,9 +58,9 @@ class ApiClient
     /**
      * @param string $endpointName
      *
-     * @return \Mockery\MockInterface
+     * @return LegacyMockInterface
      */
-    public function mock(string $endpointName): \Mockery\MockInterface
+    public function mock(string $endpointName): LegacyMockInterface
     {
         $endpointName = 'hs.'.$endpointName;
         $mock = \Mockery::mock(self::AVAILABLE_ENDPOINTS[$endpointName]);

--- a/src/Conversations/ConversationFilters.php
+++ b/src/Conversations/ConversationFilters.php
@@ -7,6 +7,7 @@ namespace HelpScout\Api\Conversations;
 use DateTime;
 use DateTimeZone;
 use HelpScout\Api\Assert\Assert;
+use HelpScout\Api\Reports\Report;
 
 class ConversationFilters
 {
@@ -76,7 +77,7 @@ class ConversationFilters
             'status' => $this->status,
             'assigned_to' => $this->assignedTo,
             'number' => $this->number,
-            'modifiedSince' => $this->modifiedSince !== null ? $this->modifiedSince->format('c') : null,
+            'modifiedSince' => $this->modifiedSince !== null ? $this->modifiedSince->format(Report::DATE_FORMAT) : null,
             'sortField' => $this->sortField,
             'sortOrder' => $this->sortOrder,
             'query' => $this->query,

--- a/src/Customers/CustomerFilters.php
+++ b/src/Customers/CustomerFilters.php
@@ -7,6 +7,7 @@ namespace HelpScout\Api\Customers;
 use DateTime;
 use DateTimeZone;
 use HelpScout\Api\Assert\Assert;
+use HelpScout\Api\Reports\Report;
 
 class CustomerFilters
 {
@@ -54,7 +55,7 @@ class CustomerFilters
             'mailbox' => $this->mailbox,
             'firstName' => $this->firstName,
             'lastName' => $this->lastName,
-            'modifiedSince' => $this->modifiedSince !== null ? $this->modifiedSince->format('c') : null,
+            'modifiedSince' => $this->modifiedSince !== null ? $this->modifiedSince->format(Report::DATE_FORMAT) : null,
             'sortField' => $this->sortField,
             'sortOrder' => $this->sortOrder,
             'query' => $this->query,

--- a/tests/ApiClientTest.php
+++ b/tests/ApiClientTest.php
@@ -13,13 +13,13 @@ use HelpScout\Api\Http\RestClient;
 use HelpScout\Api\Webhooks\WebhooksEndpoint;
 use HelpScout\Api\Workflows\WorkflowsEndpoint;
 use Mockery;
-use Mockery\MockInterface;
+use Mockery\LegacyMockInterface;
 use PHPUnit\Framework\TestCase;
 
 class ApiClientTest extends TestCase
 {
     /**
-     * @var MockInterface|Authenticator
+     * @var LegacyMockInterface|Authenticator
      */
     private $authenticator;
 
@@ -34,7 +34,7 @@ class ApiClientTest extends TestCase
     private $client;
 
     /**
-     * @var MockInterface|Client
+     * @var LegacyMockInterface|Client
      */
     private $guzzle;
 
@@ -97,7 +97,7 @@ class ApiClientTest extends TestCase
         $mockedWorkflows = $this->client->mock('workflows');
 
         $this->assertInstanceOf(WorkflowsEndpoint::class, $mockedWorkflows);
-        $this->assertInstanceOf(MockInterface::class, $mockedWorkflows);
+        $this->assertInstanceOf(LegacyMockInterface::class, $mockedWorkflows);
 
         $this->assertSame(
             $mockedWorkflows,
@@ -109,16 +109,16 @@ class ApiClientTest extends TestCase
 
         $workflows = $this->client->workflows();
         $this->assertInstanceOf(WorkflowsEndpoint::class, $workflows);
-        $this->assertFalse($workflows instanceof MockInterface);
+        $this->assertFalse($workflows instanceof LegacyMockInterface);
 
         $webhookMock = $this->client->webhooks();
-        $this->assertInstanceOf(MockInterface::class, $webhookMock);
+        $this->assertInstanceOf(LegacyMockInterface::class, $webhookMock);
 
         $this->client->clearContainer();
 
         $webhooks = $this->client->webhooks();
         $this->assertInstanceOf(WebhooksEndpoint::class, $webhooks);
-        $this->assertFalse($webhooks instanceof MockInterface);
+        $this->assertFalse($webhooks instanceof LegacyMockInterface);
     }
 
     public function testGetAuthenticator()

--- a/tests/Authentication/AuthenticationIntegrationTest.php
+++ b/tests/Authentication/AuthenticationIntegrationTest.php
@@ -13,16 +13,12 @@ use HelpScout\Api\Http\Authenticator;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 use HelpScout\Api\Tests\Payloads\CustomerPayloads;
 use Mockery;
-use Mockery\MockInterface;
 
 /**
  * @group integration
  */
 class AuthenticationIntegrationTest extends ApiClientIntegrationTestCase
 {
-    /**
-     * @var Client|MockInterface
-     */
     protected $guzzle;
 
     public function setUp()

--- a/tests/Conversations/ConversationFiltersTest.php
+++ b/tests/Conversations/ConversationFiltersTest.php
@@ -40,7 +40,7 @@ class ConversationFiltersTest extends TestCase
             'status' => 'all',
             'assigned_to' => 1771,
             'number' => 42,
-            'modifiedSince' => '2017-05-06T04:04:23+00:00',
+            'modifiedSince' => '2017-05-06T04:04:23Z',
             'sortField' => 'createdAt',
             'sortOrder' => 'asc',
             'query' => 'query',

--- a/tests/Customers/CustomerFiltersTest.php
+++ b/tests/Customers/CustomerFiltersTest.php
@@ -33,7 +33,7 @@ class CustomerFiltersTest extends TestCase
             'mailbox' => 1,
             'firstName' => 'Tom',
             'lastName' => 'Graham',
-            'modifiedSince' => '2017-05-06T04:04:23+00:00',
+            'modifiedSince' => '2017-05-06T04:04:23Z',
             'sortField' => 'firstName',
             'sortOrder' => 'asc',
             'query' => 'query',

--- a/tests/Entity/PagedCollectionTest.php
+++ b/tests/Entity/PagedCollectionTest.php
@@ -10,7 +10,7 @@ use HelpScout\Api\Http\Hal\HalLinks;
 use HelpScout\Api\Http\Hal\HalPageMetadata;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use Mockery\MockInterface;
+use Mockery\LegacyMockInterface;
 use PHPUnit\Framework\TestCase;
 
 class PagedCollectionTest extends TestCase
@@ -18,7 +18,7 @@ class PagedCollectionTest extends TestCase
     use MockeryPHPUnitIntegration;
 
     /**
-     * @var PagedCollection|MockInterface
+     * @var PagedCollection|LegacyMockInterface
      */
     private $loadedCollection;
 

--- a/tests/Http/AuthenticatorTest.php
+++ b/tests/Http/AuthenticatorTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class AuthenticatorTest extends TestCase
 {
-    /** @var MockInterface */
+    /** @var MockInterface|Mockery\LegacyMockInterface */
     public $client;
 
     public function setUp()


### PR DESCRIPTION
## Problem
Incorrect date format was used as brought up in https://github.com/helpscout/helpscout-api-php/pull/184.  This PR applies that fix to both `Customer` and `Conversation`

## Solution
 * All date formats now use the class constant for date format
 * [Mockery v1.2.3 introduced a changed to interfaces](https://github.com/mockery/mockery/pull/868) which was causing our static analysis to fail even though there was no change to functionality.  This PR adjusts the interfaces we're using in a non-breaking way.