### PR TITLE
Fixed a regression where single embedded entities would cause errors

### DIFF
--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -46,15 +46,21 @@ class HalDocument
     }
 
     /**
-     * @return HalDocument|HalDocument[]
+     * @return HalDocument[]
      */
-    public function getEmbedded(string $rel)
+    public function getEmbedded(string $rel): array
     {
         if (!$this->hasEmbedded($rel)) {
             throw new InvalidArgumentException(sprintf('The embedded resource "%s" was not found', $rel));
         }
 
-        return $this->embedded[$rel];
+        if (is_array($this->embedded[$rel])) {
+            return $this->embedded[$rel];
+        }
+
+        return [
+            $this->embedded[$rel],
+        ];
     }
 
     /**

--- a/tests/Http/Hal/HalDeserializerTest.php
+++ b/tests/Http/Hal/HalDeserializerTest.php
@@ -36,7 +36,7 @@ class HalDeserializerTest extends TestCase
 
         $this->assertInstanceOf(HalDocument::class, $halDocument);
         $this->assertTrue($halDocument->hasEmbedded('address'));
-        $this->assertInstanceOf(HalDocument::class, $halDocument->getEmbedded('address'));
+        $this->assertInstanceOf(HalDocument::class, $halDocument->getEmbedded('address')[0]);
     }
 
     public function testDeserializeDocumentWithEmptyCollection()

--- a/tests/Http/Hal/HalDocumentTest.php
+++ b/tests/Http/Hal/HalDocumentTest.php
@@ -151,6 +151,25 @@ class HalDocumentTest extends TestCase
         $this->assertTrue($documentWithLinks->hasLinks());
     }
 
+    public function testGetEmbeddedAlwaysReturnsArray()
+    {
+        $document = new HalDocument(
+            [],
+            new HalLinks([]),
+            [
+                'customers' => new HalDocument(
+                    [
+                    ],
+                    new HalLinks([
+                    ]),
+                    []
+                ),
+            ]
+        );
+        $embedded = $document->getEmbedded('customers');
+        $this->assertTrue(is_array($embedded));
+    }
+
     public function testContainsEmbeddedWhenContainsContent()
     {
         $customer = new HalDocument([


### PR DESCRIPTION
This PR re-implements the solution for the errors described in https://github.com/helpscout/helpscout-api-php/issues/187.  Looking through the PR/commit history I can't find any record of the test case re-added here being originally added or removed, despite it being present in https://github.com/helpscout/helpscout-api-php/pull/176/files.