### PR TITLE
Now correctly identifying an empty collection of embedded entities

### DIFF
--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -97,13 +97,20 @@ class HalDocument
 
     public function hasEmbedded(string $rel): bool
     {
-        // The embedded array key may be present, but we also need to verify that it has contents, since it may not
-        return array_key_exists($rel, $this->embedded) && (
-            // An embedded entity may be a single item
-            $this->embedded[$rel] instanceof HalDocument ||
+        if (!array_key_exists($rel, $this->embedded)) {
+            return false;
+        }
 
-            // It also may be a collection of HalDocuments
-            (is_array($this->embedded[$rel]) && count($this->embedded[$rel]) > 0)
-        );
+        // It may be a single entity, which means we should see if there's any data
+        if ($this->embedded[$rel] instanceof HalDocument && count($this->embedded[$rel]->getData()) > 0) {
+            return true;
+        }
+
+        // It also may be a collection of HalDocuments
+        if (is_array($this->embedded[$rel]) && count($this->embedded[$rel]) > 0) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Http/Hal/HalDocument.php
+++ b/src/Http/Hal/HalDocument.php
@@ -101,7 +101,7 @@ class HalDocument
             return false;
         }
 
-        // It may be a single entity, which means we should see if there's any data
+        // Make sure we actually have data within this embedded entity and it's not empty
         if ($this->embedded[$rel] instanceof HalDocument && count($this->embedded[$rel]->getData()) > 0) {
             return true;
         }

--- a/tests/Http/Hal/HalDocumentTest.php
+++ b/tests/Http/Hal/HalDocumentTest.php
@@ -174,10 +174,16 @@ class HalDocumentTest extends TestCase
 
     public function testDoesntContainEmbeddedWhenContentsAreEmpty()
     {
+        // When fetching a list of entities if there are zero results this will still be a HalDocument
+        $documentWithoutLinks = new HalDocument([], new HalLinks([]), [
+            'customers' => new HalDocument([], new HalLinks([]), []),
+        ]);
+        $this->assertFalse($documentWithoutLinks->hasEmbedded('conversations'));
+        $this->assertFalse($documentWithoutLinks->hasEmbedded('customers'));
+
         $documentWithoutLinks = new HalDocument([], new HalLinks([]), [
             'customers' => [],
         ]);
-
         $this->assertFalse($documentWithoutLinks->hasEmbedded('conversations'));
         $this->assertFalse($documentWithoutLinks->hasEmbedded('customers'));
     }


### PR DESCRIPTION
This PR resolves the underlying issue in https://github.com/helpscout/helpscout-api-php/issues/187 where we weren't correctly identifying empty collections of embedded entities.