### PR TITLE
Teams support

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,10 +797,16 @@ $tags = $client->tags()->list();
 
 ## Teams
 
-List the tags
+List the teams
 
 ```php
 $teams = $client->teams()->list();
+```
+
+List the members of a team
+
+```php
+$users = $client->teams()->members($teamId);
 ```
 
 ## Users

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This is the official Help Scout PHP client. This client contains methods for eas
      * [Threads](#threads)
        * [Attachments](#attachments)
    * [Tags](#tags)
+   * [Teams](#teams)
    * [Users](#users)
    * [Reports](#reports)
    * [Webhooks](#webhooks)
@@ -792,6 +793,14 @@ List the tags
 
 ```php
 $tags = $client->tags()->list();
+```
+
+## Teams
+
+List the tags
+
+```php
+$teams = $client->teams()->list();
 ```
 
 ## Users

--- a/examples/teams.php
+++ b/examples/teams.php
@@ -9,5 +9,9 @@ $client->useClientCredentials($appId, $appSecret);
 
 // List all teams
 $users = $client->teams()->list();
-
 print_r($users->getFirstPage()->toArray());
+
+// List the members of a team
+$teamMembers = $client->teams()->members(115780);
+
+

--- a/examples/teams.php
+++ b/examples/teams.php
@@ -1,0 +1,13 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require '_credentials.php';
+
+use HelpScout\Api\ApiClientFactory;
+
+$client = ApiClientFactory::createClient();
+$client->useClientCredentials($appId, $appSecret);
+
+// List all teams
+$users = $client->teams()->list();
+
+print_r($users->getFirstPage()->toArray());

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -15,6 +15,7 @@ use HelpScout\Api\Http\RestClient;
 use HelpScout\Api\Mailboxes\MailboxesEndpoint;
 use HelpScout\Api\Reports\Report;
 use HelpScout\Api\Tags\TagsEndpoint;
+use HelpScout\Api\Teams\TeamsEndpoint;
 use HelpScout\Api\Users\UsersEndpoint;
 use HelpScout\Api\Webhooks\WebhooksEndpoint;
 use HelpScout\Api\Workflows\WorkflowsEndpoint;
@@ -35,6 +36,7 @@ class ApiClient
         'hs.customerEntry' => CustomerEntryEndpoint::class,
         'hs.conversations' => ConversationsEndpoint::class,
         'hs.attachments' => AttachmentsEndpoint::class,
+        'hs.teams' => TeamsEndpoint::class,
     ];
 
     /**
@@ -286,6 +288,14 @@ class ApiClient
     public function conversations(): ConversationsEndpoint
     {
         return $this->fetchFromContainer('hs.conversations');
+    }
+
+    /**
+     * @return TeamsEndpoint
+     */
+    public function teams(): TeamsEndpoint
+    {
+        return $this->fetchFromContainer('hs.teams');
     }
 
     /**

--- a/src/Teams/Team.php
+++ b/src/Teams/Team.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Teams;
+
+use DateTime;
+use HelpScout\Api\Entity\Hydratable;
+use HelpScout\Api\Support\HydratesData;
+
+class Team implements Hydratable
+{
+    use HydratesData;
+
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var DateTime
+     */
+    private $createdAt;
+
+    /**
+     * @var DateTime
+     */
+    private $updatedAt;
+
+    /**
+     * @var string|null
+     */
+    private $name;
+
+    /**
+     * @var string|null
+     */
+    private $timezone;
+
+    /**
+     * @var string|null
+     */
+    private $photoUrl;
+
+    /**
+     * @var string|null
+     */
+    private $mention;
+
+    /**
+     * @var string|null
+     */
+    private $initials;
+
+    public function hydrate(array $data, array $embedded = [])
+    {
+        if (isset($data['id'])) {
+            $this->setId((int) $data['id']);
+        }
+        $this->setCreatedAt($this->transformDateTime($data['createdAt'] ?? null));
+        $this->setUpdatedAt($this->transformDateTime($data['updatedAt'] ?? null));
+
+        $this->setName($data['name'] ?? null);
+        $this->setTimezone($data['timezone'] ?? null);
+        $this->setPhotoUrl($data['photoUrl'] ?? null);
+        $this->setMention($data['mention'] ?? null);
+        $this->setInitials($data['initials'] ?? null);
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int|null $id
+     *
+     * @return Team
+     */
+    public function setId(?int $id): Team
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     *
+     * @return Team
+     */
+    public function setName($name): Team
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTimezone(): ?string
+    {
+        return $this->timezone;
+    }
+
+    /**
+     * @param string|null $timezone
+     *
+     * @return Team
+     */
+    public function setTimezone($timezone): Team
+    {
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPhotoUrl(): ?string
+    {
+        return $this->photoUrl;
+    }
+
+    /**
+     * @param string|null $photoUrl
+     *
+     * @return Team
+     */
+    public function setPhotoUrl($photoUrl): Team
+    {
+        $this->photoUrl = $photoUrl;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMention(): ?string
+    {
+        return $this->mention;
+    }
+
+    /**
+     * @param string|null $mention
+     *
+     * @return Team
+     */
+    public function setMention($mention): Team
+    {
+        $this->mention = $mention;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getInitials(): ?string
+    {
+        return $this->initials;
+    }
+
+    /**
+     * @param string|null $initials
+     *
+     * @return Team
+     */
+    public function setInitials($initials): Team
+    {
+        $this->initials = $initials;
+
+        return $this;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getCreatedAt(): ?DateTime
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param DateTime|null $createdAt
+     *
+     * @return Team
+     */
+    public function setCreatedAt(DateTime $createdAt = null): Team
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getUpdatedAt(): ?DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param DateTime|null $updatedAt
+     *
+     * @return Team
+     */
+    public function setUpdatedAt(DateTime $updatedAt = null): Team
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+}

--- a/src/Teams/TeamsEndpoint.php
+++ b/src/Teams/TeamsEndpoint.php
@@ -29,6 +29,8 @@ class TeamsEndpoint extends Endpoint
     /**
      * Get the members of a team
      *
+     * @param int $teamId
+     *
      * @return User[]|PagedCollection
      */
     public function members(int $teamId): PagedCollection

--- a/src/Teams/TeamsEndpoint.php
+++ b/src/Teams/TeamsEndpoint.php
@@ -15,6 +15,8 @@ class TeamsEndpoint extends Endpoint
     public const RESOURCE_KEY = 'teams';
 
     /**
+     * Get a list of teams.
+     *
      * @return Team[]|PagedCollection
      */
     public function list(): PagedCollection
@@ -27,7 +29,7 @@ class TeamsEndpoint extends Endpoint
     }
 
     /**
-     * Get the members of a team
+     * Get the members of a team.
      *
      * @param int $teamId
      *

--- a/src/Teams/TeamsEndpoint.php
+++ b/src/Teams/TeamsEndpoint.php
@@ -6,6 +6,8 @@ namespace HelpScout\Api\Teams;
 
 use HelpScout\Api\Endpoint;
 use HelpScout\Api\Entity\PagedCollection;
+use HelpScout\Api\Users\User;
+use HelpScout\Api\Users\UsersEndpoint;
 
 class TeamsEndpoint extends Endpoint
 {
@@ -21,6 +23,20 @@ class TeamsEndpoint extends Endpoint
             Team::class,
             self::RESOURCE_KEY,
             self::LIST_USERS_URI
+        );
+    }
+
+    /**
+     * Get the members of a team
+     *
+     * @return User[]|PagedCollection
+     */
+    public function members(int $teamId): PagedCollection
+    {
+        return $this->loadPage(
+            User::class,
+            UsersEndpoint::RESOURCE_KEY,
+            sprintf(self::LIST_USERS_URI.'/%d/members', $teamId)
         );
     }
 }

--- a/src/Teams/TeamsEndpoint.php
+++ b/src/Teams/TeamsEndpoint.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Teams;
+
+use HelpScout\Api\Endpoint;
+use HelpScout\Api\Entity\PagedCollection;
+
+class TeamsEndpoint extends Endpoint
+{
+    public const LIST_USERS_URI = '/v2/teams';
+    public const RESOURCE_KEY = 'teams';
+
+    /**
+     * @return Team[]|PagedCollection
+     */
+    public function list(): PagedCollection
+    {
+        return $this->loadPage(
+            Team::class,
+            self::RESOURCE_KEY,
+            self::LIST_USERS_URI
+        );
+    }
+}

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -63,6 +63,16 @@ class User implements Hydratable
      */
     private $type;
 
+    /**
+     * @var string|null
+     */
+    private $mention;
+
+    /**
+     * @var string|null
+     */
+    private $initials;
+
     public function hydrate(array $data, array $embedded = [])
     {
         if (isset($data['id'])) {
@@ -90,6 +100,8 @@ class User implements Hydratable
         $this->setTimezone($data['timezone'] ?? null);
         $this->setPhotoUrl($data['photoUrl'] ?? null);
         $this->setType($data['type'] ?? null);
+        $this->setMention($data['mention'] ?? null);
+        $this->setInitials($data['initials'] ?? null);
     }
 
     /**
@@ -290,6 +302,46 @@ class User implements Hydratable
     public function setType($type): User
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMention(): ?string
+    {
+        return $this->mention;
+    }
+
+    /**
+     * @param string|null $mention
+     *
+     * @return User
+     */
+    public function setMention($mention): User
+    {
+        $this->mention = $mention;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getInitials(): ?string
+    {
+        return $this->initials;
+    }
+
+    /**
+     * @param string|null $initials
+     *
+     * @return User
+     */
+    public function setInitials($initials): User
+    {
+        $this->initials = $initials;
 
         return $this;
     }

--- a/tests/Payloads/TeamPayloads.php
+++ b/tests/Payloads/TeamPayloads.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Payloads;
+
+class TeamPayloads
+{
+    /**
+     * @param int $id
+     *
+     * @return string
+     */
+    public static function getTeam(int $id): string
+    {
+        return json_encode(static::team($id));
+    }
+
+    /**
+     * @param int $pageNumber
+     * @param int $totalElements
+     *
+     * @return string
+     */
+    public static function getTeams(int $pageNumber, int $totalElements): string
+    {
+        $pageSize = 10;
+        $pageElements = min($totalElements, $pageSize);
+        $totalPages = ceil($totalElements / $pageSize);
+
+        // Create embedded resources
+        $teams = array_map(function ($id) {
+            return static::team($id);
+        }, range(1, $pageElements));
+
+        $data = [
+            '_embedded' => [
+                'teams' => $teams,
+            ],
+            'page' => [
+                'size' => $pageSize,
+                'totalElements' => $totalElements,
+                'totalPages' => $totalPages,
+                'number' => $pageNumber,
+            ],
+            '_links' => [
+                'self' => [
+                    'href' => 'https://api.helpscout.net/v2/teams',
+                ],
+                'next' => [
+                    'href' => 'https://api.helpscout.net/v2/teams?page=2',
+                ],
+                'first' => [
+                    'href' => 'https://api.helpscout.net/v2/teams?page=1',
+                ],
+                'last' => [
+                    'href' => "https://api.helpscout.net/v2/teams?page=$totalPages",
+                ],
+                'page' => [
+                    'href' => 'https://api.helpscout.net/v2/teams{?page}',
+                    'templated' => true,
+                ],
+            ],
+        ];
+
+        if ($pageElements === 0) {
+            // The _embedded key is not set when empty
+            unset($data['_embedded']);
+        }
+
+        return json_encode($data);
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return array
+     */
+    private static function team(int $id): array
+    {
+        return [
+            'id' => $id,
+            'createdAt' => '2019-08-23T14:39:56Z',
+            'updatedAt' => '2019-08-23T14:43:24Z',
+            'name' => 'Engineers',
+            'timezone' => 'America/New_York',
+            'photoUrl' => 'https://helpscout.com/images/avatar.jpg',
+            'mention' => 'engs',
+            '_links' => [
+                'self' => [
+                    'href' => "https://api.helpscout.net/v2/teams/$id",
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Teams/TeamClientIntegrationTest.php
+++ b/tests/Teams/TeamClientIntegrationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace HelpScout\Api\Tests\Users;
+namespace HelpScout\Api\Tests\Teams;
 
 use HelpScout\Api\Teams\Team;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;

--- a/tests/Teams/TeamClientIntegrationTest.php
+++ b/tests/Teams/TeamClientIntegrationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Users;
+
+use HelpScout\Api\Teams\Team;
+use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
+use HelpScout\Api\Tests\Payloads\TeamPayloads;
+
+/**
+ * @group integration
+ */
+class TeamClientIntegrationTest extends ApiClientIntegrationTestCase
+{
+    public function testGetTeams()
+    {
+        $this->stubResponse(
+            $this->getResponse(200, TeamPayloads::getTeams(1, 10))
+        );
+
+        $teams = $this->client->teams()->list();
+
+        $this->assertCount(10, $teams);
+        $this->assertInstanceOf(Team::class, $teams[0]);
+
+        $this->verifySingleRequest(
+            'https://api.helpscout.net/v2/teams'
+        );
+    }
+}

--- a/tests/Teams/TeamClientIntegrationTest.php
+++ b/tests/Teams/TeamClientIntegrationTest.php
@@ -7,6 +7,8 @@ namespace HelpScout\Api\Tests\Users;
 use HelpScout\Api\Teams\Team;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 use HelpScout\Api\Tests\Payloads\TeamPayloads;
+use HelpScout\Api\Tests\Payloads\UserPayloads;
+use HelpScout\Api\Users\User;
 
 /**
  * @group integration
@@ -26,6 +28,23 @@ class TeamClientIntegrationTest extends ApiClientIntegrationTestCase
 
         $this->verifySingleRequest(
             'https://api.helpscout.net/v2/teams'
+        );
+    }
+
+    public function testGetTeamMembers()
+    {
+        $this->stubResponse(
+            $this->getResponse(200, UserPayloads::getUsers(1, 10))
+        );
+
+        $teamId = 123;
+        $users = $this->client->teams()->members($teamId);
+
+        $this->assertCount(10, $users);
+        $this->assertInstanceOf(User::class, $users[0]);
+
+        $this->verifySingleRequest(
+            'https://api.helpscout.net/v2/teams/'.$teamId.'/members'
         );
     }
 }

--- a/tests/Teams/TeamTest.php
+++ b/tests/Teams/TeamTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Teams;
+
+use DateTime;
+use HelpScout\Api\Teams\Team;
+use HelpScout\Api\Users\User;
+use PHPUnit\Framework\TestCase;
+
+class TeamTest extends TestCase
+{
+    public function testHydrate()
+    {
+        $team = new Team();
+        $team->hydrate([
+            'id' => 12,
+            'name' => 'Sarah',
+            'timezone' => 'America/New_York',
+            'photoUrl' => 'https://helpscout.com/images/avatar.jpg',
+            'createdAt' => '2017-04-21T14:39:56Z',
+            'updatedAt' => '2017-04-21T14:43:24Z',
+            'mention' => 'sjones',
+            'initials' => 's',
+        ]);
+
+        $this->assertSame(12, $team->getId());
+        $this->assertInstanceOf(DateTime::class, $team->getCreatedAt());
+        $this->assertSame('2017-04-21T14:39:56+00:00', $team->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(DateTime::class, $team->getUpdatedAt());
+        $this->assertSame('2017-04-21T14:43:24+00:00', $team->getUpdatedAt()->format('c'));
+        $this->assertSame('Sarah', $team->getName());
+        $this->assertSame('America/New_York', $team->getTimezone());
+        $this->assertSame('https://helpscout.com/images/avatar.jpg', $team->getPhotoUrl());
+        $this->assertSame('sjones', $team->getMention());
+        $this->assertSame('s', $team->getInitials());
+    }
+
+    public function testHydrateWithoutCreatedAt()
+    {
+        $team = new User();
+        $team->hydrate([
+            'id' => 12,
+        ]);
+
+        $this->assertNull($team->getCreatedAt());
+    }
+
+    public function testHydrateWithoutUpdatedAt()
+    {
+        $team = new User();
+        $team->hydrate([
+            'id' => 12,
+        ]);
+
+        $this->assertNull($team->getUpdatedAt());
+    }
+}

--- a/tests/Users/UserTest.php
+++ b/tests/Users/UserTest.php
@@ -24,6 +24,8 @@ class UserTest extends TestCase
             'timezone' => 'America/New_York',
             'photoUrl' => 'https://helpscout.com/images/avatar.jpg',
             'type' => 'user',
+            'mention' => 'bman',
+            'initials' => 'BB',
         ]);
 
         $this->assertSame(12, $user->getId());
@@ -38,6 +40,8 @@ class UserTest extends TestCase
         $this->assertSame('America/New_York', $user->getTimezone());
         $this->assertSame('https://helpscout.com/images/avatar.jpg', $user->getPhotoUrl());
         $this->assertSame('user', $user->getType());
+        $this->assertSame('bman', $user->getMention());
+        $this->assertSame('BB', $user->getInitials());
     }
 
     public function testHydrateWithoutCreatedAt()


### PR DESCRIPTION
This PR fulfills https://github.com/helpscout/helpscout-api-php/issues/174 and adds team support to the SDK.  In addition to the ability to list teams and their members, this also adds `initials` and `mention` fields to the `User` entity.

## Example Usage

```
## Teams

 List the teams

$teams = $client->teams()->list();

 List the members of a team

$users = $client->teams()->members($teamId);
```