### PR TITLE
Added ability to set the status on Note and Reply threads

### DIFF
--- a/src/Conversations/Threads/NoteThread.php
+++ b/src/Conversations/Threads/NoteThread.php
@@ -22,6 +22,13 @@ class NoteThread extends Thread
         return self::TYPE;
     }
 
+    public function setStatus(?string $status): NoteThread
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
     public function extract(): array
     {
         $data = parent::extract();

--- a/src/Conversations/Threads/ReplyThread.php
+++ b/src/Conversations/Threads/ReplyThread.php
@@ -46,6 +46,13 @@ class ReplyThread extends Thread
         return $this->draft;
     }
 
+    public function setStatus(?string $status): ReplyThread
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
     public function hydrate(array $data, array $embedded = [])
     {
         parent::hydrate($data, $embedded);

--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -35,7 +35,7 @@ class Thread implements Extractable, Hydratable
     /**
      * @var string|null
      */
-    private $status;
+    protected $status;
 
     /**
      * @var string|null

--- a/tests/Conversations/Threads/NoteThreadTest.php
+++ b/tests/Conversations/Threads/NoteThreadTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Conversations\Threads;
 
+use HelpScout\Api\Conversations\Conversation;
 use HelpScout\Api\Conversations\Threads\NoteThread;
 use HelpScout\Api\Conversations\Threads\Support\HasUser;
 use HelpScout\Api\Users\User;
@@ -67,5 +68,20 @@ class NoteThreadTest extends TestCase
 
         $this->assertArrayHasKey('user', $data);
         $this->assertEquals(94320, $data['user']);
+    }
+
+    public function testDefaultsStatusToNull()
+    {
+        $thread = new NoteThread();
+        $this->assertNull($thread->getStatus());
+    }
+
+    public function testExtractsStatusWhenSet()
+    {
+        $thread = new NoteThread();
+        $thread->setStatus(Conversation::STATUS_ACTIVE);
+        $data = $thread->extract();
+        $this->assertArrayHasKey('status', $data);
+        $this->assertEquals(Conversation::STATUS_ACTIVE, $data['status']);
     }
 }

--- a/tests/Conversations/Threads/ReplyThreadTest.php
+++ b/tests/Conversations/Threads/ReplyThreadTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Conversations\Threads;
 
+use HelpScout\Api\Conversations\Conversation;
 use HelpScout\Api\Conversations\Threads\ReplyThread;
 use HelpScout\Api\Customers\Customer;
 use PHPUnit\Framework\TestCase;
@@ -130,5 +131,20 @@ class ReplyThreadTest extends TestCase
         $thread->asDraft();
         $data = $thread->extract();
         $this->assertTrue($data['draft']);
+    }
+
+    public function testDefaultsStatusToNull()
+    {
+        $thread = new ReplyThread();
+        $this->assertNull($thread->getStatus());
+    }
+
+    public function testExtractsStatusWhenSet()
+    {
+        $thread = new ReplyThread();
+        $thread->setStatus(Conversation::STATUS_ACTIVE);
+        $data = $thread->extract();
+        $this->assertArrayHasKey('status', $data);
+        $this->assertEquals(Conversation::STATUS_ACTIVE, $data['status']);
     }
 }


### PR DESCRIPTION
This PR fulfills https://github.com/helpscout/helpscout-api-php/issues/183 by adding the ability to set the status on `ReplyThread`s and `NoteThread`s.