### PR TITLE
Now providing the phone number when creating a conversation

### DIFF
--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -217,6 +217,7 @@ class Customer implements Extractable, Hydratable
             // the individual email separately, but the first email will always be a duplicate
             // of what's already in "emails"
             'email' => $this->getFirstEmail(),
+            'phone' => $this->getFirstPhone(),
 
             'address' => $this->getAddress() !== null ? $this->getAddress()->extract() : null,
 
@@ -635,6 +636,19 @@ class Customer implements Extractable, Hydratable
         $this->getEmails()->append($email);
 
         return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFirstPhone(): ?string
+    {
+        $phones = $this->phones->toArray();
+        $phone = array_shift($phones);
+
+        return $phone instanceof Phone
+            ? $phone->getValue()
+            : null;
     }
 
     /**

--- a/tests/Customers/CustomerTest.php
+++ b/tests/Customers/CustomerTest.php
@@ -357,8 +357,14 @@ class CustomerTest extends TestCase
         $this->assertEmpty($customer->getEmails());
 
         $email = new Email();
+        $emailAddress = 'test@test.com';
+        $email->setValue($emailAddress);
         $customer->addEmail($email);
         $this->assertSame($email, $customer->getEmails()->toArray()[0]);
+
+        $this->assertSame($emailAddress, $customer->getFirstEmail());
+
+        $this->assertEquals($emailAddress, $customer->extract()['email']);
     }
 
     public function testExtractEmails()
@@ -379,8 +385,14 @@ class CustomerTest extends TestCase
         $this->assertEmpty($customer->getPhones());
 
         $phone = new Phone();
+        $phoneNumber = '12357373';
+        $phone->setValue($phoneNumber);
         $customer->addPhone($phone);
         $this->assertSame($phone, $customer->getPhones()->toArray()[0]);
+
+        $this->assertEquals($phoneNumber, $customer->getFirstPhone());
+
+        $this->assertEquals($phoneNumber, $customer->extract()['phone']);
     }
 
     public function testAddPhoneShortSyntax()


### PR DESCRIPTION
This PR fulfills https://github.com/helpscout/helpscout-api-php/issues/179 by including the phone number in the Customer extraction.