### PR TITLE
Can now list users in a given mailbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,18 @@ Get users.
 $users = $client->users()->list();
 ```
 
+Narrow down the list of Users based on a set of filters.
+
+```php
+use HelpScout\Api\Users\UserFilters;
+
+$filters = (new UserFilters())
+    ->withMailbox(1)
+    ->withEmail('tester@test.com');
+
+$users = $client->users()->list($filters);
+```
+
 ## Reports
 
 When running reports using the SDK, refer to the [developer docs](https://developer.helpscout.com/mailbox-api/) for the exact endpoint, parameters, and response formats. While most of the endpoints in this SDK are little more than pass-through methods to call the API, there are a few conveniences.

--- a/examples/users.php
+++ b/examples/users.php
@@ -3,10 +3,17 @@ require __DIR__ . '/../vendor/autoload.php';
 require '_credentials.php';
 
 use HelpScout\Api\ApiClientFactory;
+use HelpScout\Api\Users\UserFilters;
 
 $client = ApiClientFactory::createClient();
 $client->useClientCredentials($appId, $appSecret);
 
+// List users
 $users = $client->users()->list();
+
+$filters = (new UserFilters())
+    ->withMailbox(197271);
+
+$users = $client->users()->list($filters);
 
 print_r($users->getFirstPage()->toArray());

--- a/src/Users/UserFilters.php
+++ b/src/Users/UserFilters.php
@@ -25,10 +25,8 @@ class UserFilters
             'email' => $this->email,
         ];
 
-        // Filter out null values
-        return array_filter($params, function ($param) {
-            return $param !== null;
-        });
+        // Filter out null values & empty strings
+        return array_filter($params);
     }
 
     /**

--- a/src/Users/UserFilters.php
+++ b/src/Users/UserFilters.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Users;
+
+use HelpScout\Api\Assert\Assert;
+
+class UserFilters
+{
+    /**
+     * @var int
+     */
+    private $mailbox;
+
+    /**
+     * @var string
+     */
+    private $email;
+
+    public function getParams(): array
+    {
+        $params = [
+            'mailbox' => $this->mailbox,
+            'email' => $this->email,
+        ];
+
+        // Filter out null values
+        return array_filter($params, function ($param) {
+            return $param !== null;
+        });
+    }
+
+    /**
+     * @return self
+     */
+    public function withMailbox(int $mailbox)
+    {
+        Assert::greaterThan($mailbox, 0);
+
+        $filters = clone $this;
+        $filters->mailbox = $mailbox;
+
+        return $filters;
+    }
+
+    /**
+     * @param string $status
+     *
+     * @return self
+     */
+    public function withEmail(string $email)
+    {
+        Assert::oneOf($email, [
+            Status::ANY,
+            Status::ACTIVE,
+            Status::OPEN,
+            Status::CLOSED,
+            Status::PENDING,
+            Status::SPAM,
+        ]);
+
+        $filters = clone $this;
+        $filters->email = $email;
+
+        return $filters;
+    }
+}

--- a/src/Users/UserFilters.php
+++ b/src/Users/UserFilters.php
@@ -43,8 +43,6 @@ class UserFilters
     }
 
     /**
-     * @param string $status
-     *
      * @return self
      */
     public function withEmail(string $email)

--- a/src/Users/UserFilters.php
+++ b/src/Users/UserFilters.php
@@ -49,15 +49,6 @@ class UserFilters
      */
     public function withEmail(string $email)
     {
-        Assert::oneOf($email, [
-            Status::ANY,
-            Status::ACTIVE,
-            Status::OPEN,
-            Status::CLOSED,
-            Status::PENDING,
-            Status::SPAM,
-        ]);
-
         $filters = clone $this;
         $filters->email = $email;
 

--- a/src/Users/UsersEndpoint.php
+++ b/src/Users/UsersEndpoint.php
@@ -33,12 +33,21 @@ class UsersEndpoint extends Endpoint
     /**
      * @return User[]|PagedCollection
      */
-    public function list(): PagedCollection
-    {
+    public function list(
+        UserFilters $userFilters = null
+    ): PagedCollection {
+        $uri = self::LIST_USERS_URI;
+        if ($userFilters) {
+            $params = $userFilters->getParams();
+            if (!empty($params)) {
+                $uri .= '?'.http_build_query($params);
+            }
+        }
+
         return $this->loadPage(
             User::class,
             self::RESOURCE_KEY,
-            self::LIST_USERS_URI
+            $uri
         );
     }
 }

--- a/tests/Users/UserClientIntegrationTest.php
+++ b/tests/Users/UserClientIntegrationTest.php
@@ -7,6 +7,7 @@ namespace HelpScout\Api\Tests\Users;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 use HelpScout\Api\Tests\Payloads\UserPayloads;
 use HelpScout\Api\Users\User;
+use HelpScout\Api\Users\UserFilters;
 
 /**
  * @group integration
@@ -107,5 +108,24 @@ class UserClientIntegrationTest extends ApiClientIntegrationTestCase
             ['GET', 'https://api.helpscout.net/v2/users'],
             ['GET', 'https://api.helpscout.net/v2/users?page=2'],
         ]);
+    }
+
+    public function testListUsersWithFilters()
+    {
+        $this->stubResponse(
+            $this->getResponse(200, UserPayloads::getUsers(1, 10))
+        );
+
+        $filters = (new UserFilters())
+            ->withMailbox(256);
+
+        $users = $this->client->users()->list($filters);
+
+        $this->assertCount(10, $users);
+        $this->assertInstanceOf(User::class, $users[0]);
+
+        $this->verifySingleRequest(
+            'https://api.helpscout.net/v2/users?mailbox=256'
+        );
     }
 }

--- a/tests/Users/UserFiltersTest.php
+++ b/tests/Users/UserFiltersTest.php
@@ -24,7 +24,7 @@ class UserFiltersTest extends TestCase
 
         $this->assertSame([
             'mailbox' => 1,
-            'folder' => 'tester@test.com',
+            'email' => 'tester@test.com',
         ], $filters->getParams());
     }
 }

--- a/tests/Users/UserFiltersTest.php
+++ b/tests/Users/UserFiltersTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Tests\Users;
+
+use HelpScout\Api\Users\UserFilters;
+use PHPUnit\Framework\TestCase;
+
+class UserFiltersTest extends TestCase
+{
+    public function testGetParamsDoesNotReturnNullValues()
+    {
+        $filters = new UserFilters();
+
+        $this->assertSame([], $filters->getParams());
+    }
+
+    public function testGetParams()
+    {
+        $filters = (new UserFilters())
+            ->withMailbox(1)
+            ->withEmail('tester@test.com');
+
+        $this->assertSame([
+            'mailbox' => 1,
+            'folder' => 'tester@test.com',
+        ], $filters->getParams());
+    }
+}


### PR DESCRIPTION
Issue https://github.com/helpscout/helpscout-api-php/issues/205 brought to light that we were missing support for filtering users by some of [the options available in the API](https://developer.helpscout.com/mailbox-api/endpoints/users/list/) (e.g. mailbox).  This was a simple, low risk change so I went ahead and added support for it.