### PR TITLE
Removing phpdoc tags that aren't needed due to strong typehints

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -49,19 +49,11 @@ class ApiClient
      */
     private $container = [];
 
-    /**
-     * @param RestClient $restClient
-     */
     public function __construct(RestClient $restClient)
     {
         $this->restClient = $restClient;
     }
 
-    /**
-     * @param string $endpointName
-     *
-     * @return LegacyMockInterface
-     */
     public function mock(string $endpointName): LegacyMockInterface
     {
         $endpointName = 'hs.'.$endpointName;
@@ -72,9 +64,6 @@ class ApiClient
         return $mock;
     }
 
-    /**
-     * @param string $endpointName
-     */
     public function clearMock(string $endpointName): void
     {
         $endpointName = 'hs.'.$endpointName;
@@ -86,19 +75,11 @@ class ApiClient
         $this->container = [];
     }
 
-    /**
-     * @return Authenticator
-     */
     public function getAuthenticator(): Authenticator
     {
         return $this->restClient->getAuthenticator();
     }
 
-    /**
-     * @param string $accessToken
-     *
-     * @return ApiClient
-     */
     public function setAccessToken(string $accessToken): ApiClient
     {
         $this->getAuthenticator()
@@ -107,21 +88,12 @@ class ApiClient
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getTokens(): array
     {
         return $this->getAuthenticator()
             ->getTokens();
     }
 
-    /**
-     * @param string $appId
-     * @param string $appSecret
-     *
-     * @return ApiClient
-     */
     public function useClientCredentials(string $appId, string $appSecret): ApiClient
     {
         $this->getAuthenticator()
@@ -136,11 +108,6 @@ class ApiClient
      * sunset v1 of the API. At that time, this method will no longer function
      * and we will remove it from the SDK.
      *
-     * @param string $clientId
-     * @param string $apiKey
-     *
-     * @return ApiClient
-     *
      * @deprecated
      */
     public function useLegacyToken(string $clientId, string $apiKey): ApiClient
@@ -151,13 +118,6 @@ class ApiClient
         return $this;
     }
 
-    /**
-     * @param string $appId
-     * @param string $appSecret
-     * @param string $refreshToken
-     *
-     * @return ApiClient
-     */
     public function useRefreshToken(string $appId, string $appSecret, string $refreshToken): ApiClient
     {
         $this->getAuthenticator()
@@ -168,12 +128,6 @@ class ApiClient
 
     /**
      * Takes an authorization code and exchanges it for an access/refresh token pair.
-     *
-     * @param string $appId
-     * @param string $appSecret
-     * @param string $authorizationCode
-     *
-     * @return ApiClient
      */
     public function swapAuthorizationCodeForReusableTokens(
         string $appId,
@@ -190,12 +144,6 @@ class ApiClient
         return $this;
     }
 
-    /**
-     * @param string $reportName
-     * @param array  $params
-     *
-     * @return array
-     */
     public function runReport(string $reportName, array $params = []): array
     {
         if (!\class_exists($reportName)) {
@@ -209,8 +157,6 @@ class ApiClient
     }
 
     /**
-     * @param string $key
-     *
      * @return mixed
      */
     protected function fetchFromContainer(string $key)
@@ -226,89 +172,56 @@ class ApiClient
         }
     }
 
-    /**
-     * @return WorkflowsEndpoint
-     */
     public function workflows(): WorkflowsEndpoint
     {
         return $this->fetchFromContainer('hs.workflows');
     }
 
-    /**
-     * @return WebhooksEndpoint
-     */
     public function webhooks(): WebhooksEndpoint
     {
         return $this->fetchFromContainer('hs.webhooks');
     }
 
-    /**
-     * @return UsersEndpoint
-     */
     public function users(): UsersEndpoint
     {
         return $this->fetchFromContainer('hs.users');
     }
 
-    /**
-     * @return TagsEndpoint
-     */
     public function tags(): TagsEndpoint
     {
         return $this->fetchFromContainer('hs.tags');
     }
 
-    /**
-     * @return MailboxesEndpoint
-     */
     public function mailboxes(): MailboxesEndpoint
     {
         return $this->fetchFromContainer('hs.mailboxes');
     }
 
-    /**
-     * @return CustomersEndpoint
-     */
     public function customers(): CustomersEndpoint
     {
         return $this->fetchFromContainer('hs.customers');
     }
 
-    /**
-     * @return CustomerEntryEndpoint
-     */
     public function customerEntry(): CustomerEntryEndpoint
     {
         return $this->fetchFromContainer('hs.customerEntry');
     }
 
-    /**
-     * @return ConversationsEndpoint
-     */
     public function conversations(): ConversationsEndpoint
     {
         return $this->fetchFromContainer('hs.conversations');
     }
 
-    /**
-     * @return TeamsEndpoint
-     */
     public function teams(): TeamsEndpoint
     {
         return $this->fetchFromContainer('hs.teams');
     }
 
-    /**
-     * @return ThreadsEndpoint
-     */
     public function threads(): ThreadsEndpoint
     {
         return $this->fetchFromContainer('hs.threads');
     }
 
-    /**
-     * @return AttachmentsEndpoint
-     */
     public function attachments(): AttachmentsEndpoint
     {
         return $this->fetchFromContainer('hs.attachments');

--- a/src/ApiClientFactory.php
+++ b/src/ApiClientFactory.php
@@ -8,11 +8,6 @@ use HelpScout\Api\Http\RestClientBuilder;
 
 class ApiClientFactory
 {
-    /**
-     * @param array $config
-     *
-     * @return ApiClient
-     */
     public static function createClient(array $config = []): ApiClient
     {
         $restClientBuilder = new RestClientBuilder($config);

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -727,8 +727,6 @@ class Conversation implements Extractable, Hydratable
 
     /**
      * @param Tag[]|Collection $tags
-     *
-     * @return Conversation
      */
     public function setTags(Collection $tags): Conversation
     {
@@ -754,8 +752,6 @@ class Conversation implements Extractable, Hydratable
 
     /**
      * @param CustomField[]|Collection $customFields
-     *
-     * @return Conversation
      */
     public function setCustomFields(Collection $customFields): Conversation
     {
@@ -790,8 +786,6 @@ class Conversation implements Extractable, Hydratable
 
     /**
      * @param Thread[]|Collection $threads
-     *
-     * @return Conversation
      */
     public function setThreads(Collection $threads): Conversation
     {

--- a/src/Conversations/ConversationFilters.php
+++ b/src/Conversations/ConversationFilters.php
@@ -66,9 +66,6 @@ class ConversationFilters
      */
     private $query;
 
-    /**
-     * @return array
-     */
     public function getParams(): array
     {
         $params = [
@@ -98,10 +95,7 @@ class ConversationFilters
     }
 
     /**
-     * @param int   $id
      * @param mixed $value
-     *
-     * @return ConversationFilters
      */
     public function withCustomFieldById(int $id, $value): ConversationFilters
     {
@@ -114,11 +108,6 @@ class ConversationFilters
         return $filters;
     }
 
-    /**
-     * @param array $fields
-     *
-     * @return ConversationFilters
-     */
     public function withCustomFieldsById(array $fields): ConversationFilters
     {
         $filters = clone $this;
@@ -128,8 +117,6 @@ class ConversationFilters
     }
 
     /**
-     * @param int $mailbox
-     *
      * @return self
      */
     public function withMailbox(int $mailbox)
@@ -143,8 +130,6 @@ class ConversationFilters
     }
 
     /**
-     * @param int $folderId
-     *
      * @return self
      */
     public function withFolder(int $folderId)
@@ -156,8 +141,6 @@ class ConversationFilters
     }
 
     /**
-     * @param string $status
-     *
      * @return self
      */
     public function withStatus(string $status)
@@ -193,8 +176,6 @@ class ConversationFilters
     }
 
     /**
-     * @param array $tags
-     *
      * @return self
      */
     public function withTags(array $tags)
@@ -206,8 +187,6 @@ class ConversationFilters
     }
 
     /**
-     * @param int $assigneeId
-     *
      * @return self
      */
     public function withAssignedTo(int $assigneeId)
@@ -219,8 +198,6 @@ class ConversationFilters
     }
 
     /**
-     * @param DateTime $modifiedSince
-     *
      * @return self
      */
     public function withModifiedSince(DateTime $modifiedSince)
@@ -234,8 +211,6 @@ class ConversationFilters
     }
 
     /**
-     * @param int $number
-     *
      * @return self
      */
     public function withNumber(int $number)
@@ -247,8 +222,6 @@ class ConversationFilters
     }
 
     /**
-     * @param string $sortField
-     *
      * @return self
      */
     public function withSortField(string $sortField)
@@ -271,8 +244,6 @@ class ConversationFilters
     }
 
     /**
-     * @param string $sortOrder
-     *
      * @return self
      */
     public function withSortOrder(string $sortOrder)
@@ -290,8 +261,6 @@ class ConversationFilters
     }
 
     /**
-     * @param string $query
-     *
      * @see https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/#query
      *
      * @return self

--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -15,12 +15,6 @@ use HelpScout\Api\Tags\TagsCollection;
 
 class ConversationsEndpoint extends Endpoint
 {
-    /**
-     * @param int                      $id
-     * @param ConversationRequest|null $conversationRequest
-     *
-     * @return Conversation
-     */
     public function get(int $id, ConversationRequest $conversationRequest = null): Conversation
     {
         $conversationResource = $this->restClient->getResource(Conversation::class, sprintf('/v2/conversations/%d', $id));
@@ -28,20 +22,13 @@ class ConversationsEndpoint extends Endpoint
         return $this->hydrateConversationWithSubEntities($conversationResource, $conversationRequest ?: new ConversationRequest());
     }
 
-    /**
-     * @param int $conversationId
-     */
     public function delete(int $conversationId): void
     {
         $this->restClient->deleteResource(sprintf('/v2/conversations/%d', $conversationId));
     }
 
     /**
-     * @param Conversation $conversation
-     *
      * @throws ValidationErrorException
-     *
-     * @return int|null
      */
     public function create(Conversation $conversation): ?int
     {
@@ -51,7 +38,6 @@ class ConversationsEndpoint extends Endpoint
     /**
      * Updates the custom field values for a given conversation.  Ommitted fields are removed.
      *
-     * @param int                                                   $conversationId
      * @param CustomField[]|array|Collection|CustomFieldsCollection $customFields
      *
      * @throws ValidationErrorException
@@ -79,7 +65,6 @@ class ConversationsEndpoint extends Endpoint
      * Updates the tags for a given conversation.
      * Omitted tags are removed.
      *
-     * @param int                             $conversationId
      * @param array|Collection|TagsCollection $tags
      *
      * @throws ValidationErrorException
@@ -108,9 +93,6 @@ class ConversationsEndpoint extends Endpoint
     }
 
     /**
-     * @param ConversationFilters|null $conversationFilters
-     * @param ConversationRequest|null $conversationRequest
-     *
      * @return Conversation[]|PagedCollection
      */
     public function list(
@@ -132,9 +114,6 @@ class ConversationsEndpoint extends Endpoint
     }
 
     /**
-     * @param string              $uri
-     * @param ConversationRequest $conversationRequest
-     *
      * @return Conversation[]|PagedCollection
      */
     private function loadConversations(string $uri, ConversationRequest $conversationRequest): PagedCollection
@@ -155,12 +134,6 @@ class ConversationsEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param HalResource         $conversationResource
-     * @param ConversationRequest $conversationRequest
-     *
-     * @return Conversation
-     */
     private function hydrateConversationWithSubEntities(
         HalResource $conversationResource,
         ConversationRequest $conversationRequest
@@ -173,9 +146,6 @@ class ConversationsEndpoint extends Endpoint
 
     /**
      * Move a conversation to a given mailbox.
-     *
-     * @param int $conversationId
-     * @param int $toMailboxId
      */
     public function move(int $conversationId, int $toMailboxId): void
     {
@@ -185,9 +155,6 @@ class ConversationsEndpoint extends Endpoint
 
     /**
      * Update the subject of a conversation.
-     *
-     * @param int    $conversationId
-     * @param string $subject
      *
      * @throws ValidationErrorException
      */
@@ -200,9 +167,6 @@ class ConversationsEndpoint extends Endpoint
     /**
      * Change the customer associated with a conversation.
      *
-     * @param int $conversationId
-     * @param int $newCustomerId
-     *
      * @throws ValidationErrorException
      */
     public function updateCustomer(int $conversationId, int $newCustomerId): void
@@ -211,9 +175,6 @@ class ConversationsEndpoint extends Endpoint
         $this->patchConversation($conversationId, $patch);
     }
 
-    /**
-     * @param int $conversationId
-     */
     public function publishDraft(int $conversationId): void
     {
         $patch = Patch::replace('draft', true);
@@ -221,9 +182,6 @@ class ConversationsEndpoint extends Endpoint
     }
 
     /**
-     * @param int    $conversationId
-     * @param string $status
-     *
      * @throws ValidationErrorException
      */
     public function updateStatus(int $conversationId, string $status): void
@@ -232,29 +190,18 @@ class ConversationsEndpoint extends Endpoint
         $this->patchConversation($conversationId, $patch);
     }
 
-    /**
-     * @param int $conversationId
-     * @param int $assigneeId
-     */
     public function assign(int $conversationId, int $assigneeId): void
     {
         $patch = Patch::replace('assignTo', $assigneeId);
         $this->patchConversation($conversationId, $patch);
     }
 
-    /**
-     * @param int $conversationId
-     */
     public function unassign(int $conversationId): void
     {
         $patch = Patch::remove('assignTo');
         $this->patchConversation($conversationId, $patch);
     }
 
-    /**
-     * @param int   $conversationId
-     * @param Patch $patch
-     */
     private function patchConversation(int $conversationId, Patch $patch): void
     {
         $this->restClient->patchResource($patch, sprintf('/v2/conversations/%d', $conversationId));

--- a/src/Conversations/CustomerWaitingSince.php
+++ b/src/Conversations/CustomerWaitingSince.php
@@ -55,9 +55,6 @@ class CustomerWaitingSince implements Extractable, Hydratable
         return $fields;
     }
 
-    /**
-     * @param DateTime|null $time
-     */
     public function setTime(DateTime $time = null): self
     {
         $this->time = $time;

--- a/src/Conversations/Threads/Attachments/Attachment.php
+++ b/src/Conversations/Threads/Attachments/Attachment.php
@@ -52,9 +52,6 @@ class Attachment implements Extractable, Hydratable
      */
     private $webUrl;
 
-    /**
-     * @return array
-     */
     public function extract(): array
     {
         return [
@@ -135,8 +132,6 @@ class Attachment implements Extractable, Hydratable
 
     /**
      * @param string|null $filename
-     *
-     * @return Attachment
      */
     public function setFilename($filename): Attachment
     {
@@ -152,8 +147,6 @@ class Attachment implements Extractable, Hydratable
 
     /**
      * @param string|null $mimeType
-     *
-     * @return Attachment
      */
     public function setMimeType($mimeType): Attachment
     {
@@ -169,8 +162,6 @@ class Attachment implements Extractable, Hydratable
 
     /**
      * @param string|null $data
-     *
-     * @return Attachment
      */
     public function setData($data): Attachment
     {

--- a/src/Conversations/Threads/Attachments/AttachmentsEndpoint.php
+++ b/src/Conversations/Threads/Attachments/AttachmentsEndpoint.php
@@ -8,12 +8,6 @@ use HelpScout\Api\Endpoint;
 
 class AttachmentsEndpoint extends Endpoint
 {
-    /**
-     * @param int $conversationId
-     * @param int $attachmentId
-     *
-     * @return Attachment
-     */
     public function get(int $conversationId, int $attachmentId): Attachment
     {
         $attachmentResource = $this->restClient->getResource(
@@ -24,13 +18,6 @@ class AttachmentsEndpoint extends Endpoint
         return $attachmentResource->getEntity();
     }
 
-    /**
-     * @param int        $conversationId
-     * @param int        $threadId
-     * @param Attachment $attachment
-     *
-     * @return int|null
-     */
     public function create(int $conversationId, int $threadId, Attachment $attachment): ?int
     {
         return $this->restClient->createResource(
@@ -39,10 +26,6 @@ class AttachmentsEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $conversationId
-     * @param int $attachmentId
-     */
     public function delete(int $conversationId, int $attachmentId): void
     {
         $this->restClient->deleteResource(

--- a/src/Conversations/Threads/ThreadsEndpoint.php
+++ b/src/Conversations/Threads/ThreadsEndpoint.php
@@ -12,22 +12,11 @@ use HelpScout\Api\Http\Hal\HalResource;
 
 class ThreadsEndpoint extends Endpoint
 {
-    /**
-     * @param int $conversationId
-     *
-     * @return PagedCollection
-     */
     public function list(int $conversationId): PagedCollection
     {
         return $this->loadThreads(sprintf('/v2/conversations/%d/threads', $conversationId));
     }
 
-    /**
-     * @param int    $conversationId
-     * @param Thread $thread
-     *
-     * @return int|null
-     */
     public function create(int $conversationId, Thread $thread): ?int
     {
         return $this->restClient->createResource(
@@ -36,11 +25,6 @@ class ThreadsEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int    $conversationId
-     * @param int    $threadId
-     * @param string $newText
-     */
     public function updateText(int $conversationId, int $threadId, string $newText): void
     {
         $patch = Patch::replace('text', $newText);
@@ -51,8 +35,6 @@ class ThreadsEndpoint extends Endpoint
     }
 
     /**
-     * @param string $uri
-     *
      * @return Thread[]|PagedCollection
      */
     private function loadThreads(string $uri): PagedCollection

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -229,19 +229,11 @@ class Customer implements Extractable, Hydratable
         ]);
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Customer
-     */
     public function setId(int $id): Customer
     {
         Assert::greaterThan($id, 0);
@@ -251,19 +243,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return DateTime|null
-     */
     public function getCreatedAt(): ?DateTime
     {
         return $this->createdAt;
     }
 
-    /**
-     * @param DateTime|null $createdAt
-     *
-     * @return Customer
-     */
     public function setCreatedAt(DateTime $createdAt = null): Customer
     {
         $this->createdAt = $createdAt;
@@ -271,19 +255,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return DateTime|null
-     */
     public function getUpdatedAt(): ?DateTime
     {
         return $this->updatedAt;
     }
 
-    /**
-     * @param DateTime|null $updatedAt
-     *
-     * @return Customer
-     */
     public function setUpdatedAt(DateTime $updatedAt = null): Customer
     {
         $this->updatedAt = $updatedAt;
@@ -291,19 +267,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFirstName(): ?string
     {
         return $this->firstName;
     }
 
-    /**
-     * @param string|null $firstName
-     *
-     * @return Customer
-     */
     public function setFirstName(?string $firstName): Customer
     {
         $this->firstName = $firstName;
@@ -311,19 +279,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getLastName(): ?string
     {
         return $this->lastName;
     }
 
-    /**
-     * @param string|null $lastName
-     *
-     * @return Customer
-     */
     public function setLastName(?string $lastName): Customer
     {
         $this->lastName = $lastName;
@@ -331,19 +291,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getGender(): ?string
     {
         return $this->gender;
     }
 
-    /**
-     * @param string|null $gender
-     *
-     * @return Customer
-     */
     public function setGender(?string $gender): Customer
     {
         $this->gender = $gender;
@@ -351,19 +303,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getJobTitle(): ?string
     {
         return $this->jobTitle;
     }
 
-    /**
-     * @param string|null $jobTitle
-     *
-     * @return Customer
-     */
     public function setJobTitle(?string $jobTitle): Customer
     {
         $this->jobTitle = $jobTitle;
@@ -371,19 +315,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getLocation(): ?string
     {
         return $this->location;
     }
 
-    /**
-     * @param string|null $location
-     *
-     * @return Customer
-     */
     public function setLocation(?string $location): Customer
     {
         $this->location = $location;
@@ -391,19 +327,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getOrganization(): ?string
     {
         return $this->organization;
     }
 
-    /**
-     * @param string|null $organization
-     *
-     * @return Customer
-     */
     public function setOrganization(?string $organization): Customer
     {
         $this->organization = $organization;
@@ -411,19 +339,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPhotoType(): ?string
     {
         return $this->photoType;
     }
 
-    /**
-     * @param string|null $photoType
-     *
-     * @return Customer
-     */
     public function setPhotoType(?string $photoType): Customer
     {
         $this->photoType = $photoType;
@@ -431,19 +351,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPhotoUrl(): ?string
     {
         return $this->photoUrl;
     }
 
-    /**
-     * @param string|null $photoUrl
-     *
-     * @return Customer
-     */
     public function setPhotoUrl(?string $photoUrl): Customer
     {
         $this->photoUrl = $photoUrl;
@@ -451,19 +363,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getBackground(): ?string
     {
         return $this->background;
     }
 
-    /**
-     * @param string|null $background
-     *
-     * @return Customer
-     */
     public function setBackground(?string $background): Customer
     {
         $this->background = $background;
@@ -471,19 +375,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAge(): ?string
     {
         return $this->age;
     }
 
-    /**
-     * @param string|null $age
-     *
-     * @return Customer
-     */
     public function setAge(?string $age): Customer
     {
         $this->age = $age;
@@ -491,19 +387,11 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return Address|null
-     */
     public function getAddress(): ?Address
     {
         return $this->address;
     }
 
-    /**
-     * @param Address|null $address
-     *
-     * @return Customer
-     */
     public function setAddress(?Address $address): Customer
     {
         $this->address = $address;
@@ -521,8 +409,6 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param ChatHandle[]|Collection $chats
-     *
-     * @return Customer
      */
     public function setChatHandles(Collection $chats): Customer
     {
@@ -565,8 +451,6 @@ class Customer implements Extractable, Hydratable
      * @deprecated
      *
      * @param ChatHandle[]|Collection $chats
-     *
-     * @return Customer
      */
     public function setChats(Collection $chats): Customer
     {
@@ -593,9 +477,6 @@ class Customer implements Extractable, Hydratable
         return $this->emails;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFirstEmail(): ?string
     {
         $emails = $this->emails->toArray();
@@ -608,8 +489,6 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Email[]|Collection $emails
-     *
-     * @return Customer
      */
     public function setEmails(Collection $emails): Customer
     {
@@ -638,9 +517,6 @@ class Customer implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFirstPhone(): ?string
     {
         $phones = $this->phones->toArray();
@@ -661,8 +537,6 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Phone[]|Collection $phones
-     *
-     * @return Customer
      */
     public function setPhones(Collection $phones): Customer
     {
@@ -701,8 +575,6 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param SocialProfile[]|Collection $socialProfiles
-     *
-     * @return Customer
      */
     public function setSocialProfiles(Collection $socialProfiles): Customer
     {
@@ -741,8 +613,6 @@ class Customer implements Extractable, Hydratable
 
     /**
      * @param Website[]|Collection $websites
-     *
-     * @return Customer
      */
     public function setWebsites(Collection $websites): Customer
     {

--- a/src/Customers/CustomerFilters.php
+++ b/src/Customers/CustomerFilters.php
@@ -46,9 +46,6 @@ class CustomerFilters
      */
     private $query;
 
-    /**
-     * @return array
-     */
     public function getParams(): array
     {
         $params = [
@@ -68,8 +65,6 @@ class CustomerFilters
     }
 
     /**
-     * @param int $mailbox
-     *
      * @return self
      */
     public function withMailbox(int $mailbox)
@@ -83,8 +78,6 @@ class CustomerFilters
     }
 
     /**
-     * @param string $firstName
-     *
      * @return self
      */
     public function withFirstName(string $firstName)
@@ -96,8 +89,6 @@ class CustomerFilters
     }
 
     /**
-     * @param string $lastName
-     *
      * @return self
      */
     public function withLastName(string $lastName)
@@ -109,8 +100,6 @@ class CustomerFilters
     }
 
     /**
-     * @param DateTime $modifiedSince
-     *
      * @return self
      */
     public function withModifiedSince(DateTime $modifiedSince)
@@ -124,8 +113,6 @@ class CustomerFilters
     }
 
     /**
-     * @param string $sortField
-     *
      * @return self
      */
     public function withSortField(string $sortField)
@@ -139,8 +126,6 @@ class CustomerFilters
     }
 
     /**
-     * @param string $sortOrder
-     *
      * @return self
      */
     public function withSortOrder(string $sortOrder)
@@ -155,8 +140,6 @@ class CustomerFilters
     }
 
     /**
-     * @param string $query
-     *
      * @see https://developer.helpscout.com/mailbox-api/endpoints/customers/list/#query
      *
      * @return self

--- a/src/Customers/CustomerRequest.php
+++ b/src/Customers/CustomerRequest.php
@@ -19,9 +19,6 @@ class CustomerRequest
      */
     private $links = [];
 
-    /**
-     * @param array $links
-     */
     public function __construct(array $links = [])
     {
         foreach ($links as $link) {
@@ -29,17 +26,11 @@ class CustomerRequest
         }
     }
 
-    /**
-     * @return array
-     */
     public function getLinks(): array
     {
         return $this->links;
     }
 
-    /**
-     * @param string $link
-     */
     private function addLink(string $link)
     {
         Assert::oneOf($link, [
@@ -54,69 +45,41 @@ class CustomerRequest
         $this->links[] = $link;
     }
 
-    /**
-     * @param string $rel
-     *
-     * @return bool
-     */
     public function hasLink(string $rel): bool
     {
         return in_array($rel, $this->links, true);
     }
 
-    /**
-     * @return self
-     */
     public function withAddress(): self
     {
         return $this->with(CustomerLinks::ADDRESS);
     }
 
-    /**
-     * @return self
-     */
     public function withChats(): self
     {
         return $this->with(CustomerLinks::CHATS);
     }
 
-    /**
-     * @return self
-     */
     public function withEmails(): self
     {
         return $this->with(CustomerLinks::EMAILS);
     }
 
-    /**
-     * @return self
-     */
     public function withPhones(): self
     {
         return $this->with(CustomerLinks::PHONES);
     }
 
-    /**
-     * @return self
-     */
     public function withSocialProfiles(): self
     {
         return $this->with(CustomerLinks::SOCIAL_PROFILES);
     }
 
-    /**
-     * @return self
-     */
     public function withWebsites(): self
     {
         return $this->with(CustomerLinks::WEBSITES);
     }
 
-    /**
-     * @param string $link
-     *
-     * @return self
-     */
     private function with(string $link): self
     {
         $request = clone $this;

--- a/src/Customers/CustomersEndpoint.php
+++ b/src/Customers/CustomersEndpoint.php
@@ -13,11 +13,7 @@ use HelpScout\Api\Http\Hal\HalResource;
 class CustomersEndpoint extends Endpoint
 {
     /**
-     * @param Customer $customer
-     *
      * @throws ValidationErrorException
-     *
-     * @return int|null
      */
     public function create(Customer $customer): ?int
     {
@@ -28,8 +24,6 @@ class CustomersEndpoint extends Endpoint
     }
 
     /**
-     * @param Customer $customer
-     *
      * @throws ValidationErrorException
      */
     public function update(Customer $customer): void
@@ -40,12 +34,6 @@ class CustomersEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int                  $id
-     * @param CustomerRequest|null $customerRequest
-     *
-     * @return Customer
-     */
     public function get(int $id, CustomerRequest $customerRequest = null): Customer
     {
         $customerResource = $this->restClient->getResource(
@@ -60,9 +48,6 @@ class CustomersEndpoint extends Endpoint
     }
 
     /**
-     * @param CustomerFilters|null $customerFilters
-     * @param CustomerRequest|null $customerRequest
-     *
      * @return Customer[]|PagedCollection
      */
     public function list(
@@ -84,9 +69,6 @@ class CustomersEndpoint extends Endpoint
     }
 
     /**
-     * @param string          $uri
-     * @param CustomerRequest $customerRequest
-     *
      * @return Customer[]|PagedCollection
      */
     private function loadCustomers(
@@ -115,12 +97,6 @@ class CustomersEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param HalResource     $customerResource
-     * @param CustomerRequest $customerRequest
-     *
-     * @return Customer
-     */
     private function hydrateCustomerWithSubEntities(
         HalResource $customerResource,
         CustomerRequest $customerRequest

--- a/src/Customers/Entry/Address.php
+++ b/src/Customers/Entry/Address.php
@@ -57,9 +57,6 @@ class Address implements Extractable, Hydratable
         ];
     }
 
-    /**
-     * @return string|null
-     */
     public function getCity(): ?string
     {
         return $this->city;
@@ -67,8 +64,6 @@ class Address implements Extractable, Hydratable
 
     /**
      * @param string|null $city
-     *
-     * @return Address
      */
     public function setCity($city): Address
     {
@@ -85,11 +80,6 @@ class Address implements Extractable, Hydratable
         return $this->lines;
     }
 
-    /**
-     * @param array $lines
-     *
-     * @return Address
-     */
     public function setLines(array $lines): Address
     {
         $this->lines = $lines;
@@ -97,9 +87,6 @@ class Address implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getState(): ?string
     {
         return $this->state;
@@ -107,8 +94,6 @@ class Address implements Extractable, Hydratable
 
     /**
      * @param string|null $state
-     *
-     * @return Address
      */
     public function setState($state): Address
     {
@@ -117,9 +102,6 @@ class Address implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPostalCode(): ?string
     {
         return $this->postalCode;
@@ -127,8 +109,6 @@ class Address implements Extractable, Hydratable
 
     /**
      * @param string|null $postalCode
-     *
-     * @return Address
      */
     public function setPostalCode($postalCode): Address
     {
@@ -137,9 +117,6 @@ class Address implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getCountry(): ?string
     {
         return $this->country;
@@ -147,8 +124,6 @@ class Address implements Extractable, Hydratable
 
     /**
      * @param string|null $country
-     *
-     * @return Address
      */
     public function setCountry($country): Address
     {

--- a/src/Customers/Entry/Chat.php
+++ b/src/Customers/Entry/Chat.php
@@ -52,19 +52,11 @@ class Chat implements Extractable, Hydratable
         ];
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Chat
-     */
     public function setId(int $id): Chat
     {
         Assert::greaterThan($id, 0);
@@ -74,9 +66,6 @@ class Chat implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getValue(): ?string
     {
         return $this->value;
@@ -84,8 +73,6 @@ class Chat implements Extractable, Hydratable
 
     /**
      * @param string|null $value
-     *
-     * @return Chat
      */
     public function setValue($value): Chat
     {
@@ -94,9 +81,6 @@ class Chat implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
@@ -104,8 +88,6 @@ class Chat implements Extractable, Hydratable
 
     /**
      * @param string|null $type
-     *
-     * @return Chat
      */
     public function setType($type): Chat
     {

--- a/src/Customers/Entry/CustomerEntryEndpoint.php
+++ b/src/Customers/Entry/CustomerEntryEndpoint.php
@@ -20,12 +20,6 @@ class CustomerEntryEndpoint extends Endpoint
     public const CREATE_CUSTOMER_WEBSITE = '/v2/customers/%d/websites';
     public const CUSTOMER_WEBSITE = '/v2/customers/%d/websites/%d';
 
-    /**
-     * @param int     $customerId
-     * @param Address $address
-     *
-     * @return int|null
-     */
     public function createAddress(int $customerId, Address $address): ?int
     {
         return $this->restClient->createResource(
@@ -34,10 +28,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int     $customerId
-     * @param Address $address
-     */
     public function updateAddress(int $customerId, Address $address): void
     {
         $this->restClient->updateResource(
@@ -45,9 +35,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $customerId
-     */
     public function deleteAddress(int $customerId): void
     {
         $this->restClient->deleteResource(
@@ -55,12 +42,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int        $customerId
-     * @param ChatHandle $chat
-     *
-     * @return int|null
-     */
     public function createChat(int $customerId, ChatHandle $chat): ?int
     {
         return $this->restClient->createResource(
@@ -69,10 +50,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int        $customerId
-     * @param ChatHandle $chat
-     */
     public function updateChat(int $customerId, ChatHandle $chat): void
     {
         $this->restClient->updateResource(
@@ -81,10 +58,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $customerId
-     * @param int $chatId
-     */
     public function deleteChat(int $customerId, int $chatId): void
     {
         $this->restClient->deleteResource(
@@ -92,12 +65,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int   $customerId
-     * @param Email $email
-     *
-     * @return int|null
-     */
     public function createEmail(int $customerId, Email $email): ?int
     {
         return $this->restClient->createResource(
@@ -106,10 +73,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int   $customerId
-     * @param Email $email
-     */
     public function updateEmail(int $customerId, Email $email): void
     {
         $this->restClient->updateResource(
@@ -118,10 +81,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $customerId
-     * @param int $emailId
-     */
     public function deleteEmail(int $customerId, int $emailId): void
     {
         $this->restClient->deleteResource(
@@ -129,12 +88,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int   $customerId
-     * @param Phone $phone
-     *
-     * @return int|null
-     */
     public function createPhone(int $customerId, Phone $phone): ?int
     {
         return $this->restClient->createResource(
@@ -143,10 +96,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int   $customerId
-     * @param Phone $phone
-     */
     public function updatePhone(int $customerId, Phone $phone): void
     {
         $this->restClient->updateResource(
@@ -155,10 +104,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $customerId
-     * @param int $phoneId
-     */
     public function deletePhone(int $customerId, int $phoneId): void
     {
         $this->restClient->deleteResource(
@@ -166,12 +111,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int           $customerId
-     * @param SocialProfile $socialProfile
-     *
-     * @return int|null
-     */
     public function createSocialProfile(int $customerId, SocialProfile $socialProfile): ?int
     {
         return $this->restClient->createResource(
@@ -180,10 +119,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int           $customerId
-     * @param SocialProfile $socialProfile
-     */
     public function updateSocialProfile(int $customerId, SocialProfile $socialProfile): void
     {
         $this->restClient->updateResource(
@@ -192,10 +127,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $customerId
-     * @param int $socialProfileId
-     */
     public function deleteSocialProfile(int $customerId, int $socialProfileId): void
     {
         $this->restClient->deleteResource(
@@ -203,12 +134,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int     $customerId
-     * @param Website $website
-     *
-     * @return int|null
-     */
     public function createWebsite(int $customerId, Website $website): ?int
     {
         return $this->restClient->createResource(
@@ -217,10 +142,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int     $customerId
-     * @param Website $website
-     */
     public function updateWebsite(int $customerId, Website $website): void
     {
         $this->restClient->updateResource(
@@ -229,10 +150,6 @@ class CustomerEntryEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $customerId
-     * @param int $websiteId
-     */
     public function deleteWebsite(int $customerId, int $websiteId): void
     {
         $this->restClient->deleteResource(

--- a/src/Customers/Entry/Email.php
+++ b/src/Customers/Entry/Email.php
@@ -46,19 +46,11 @@ class Email implements Extractable, Hydratable
         ];
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Email
-     */
     public function setId(int $id): Email
     {
         Assert::greaterThan($id, 0);
@@ -68,19 +60,11 @@ class Email implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getValue(): ?string
     {
         return $this->value;
     }
 
-    /**
-     * @param string|null $value
-     *
-     * @return Email
-     */
     public function setValue(?string $value): Email
     {
         $this->value = $value;
@@ -88,19 +72,11 @@ class Email implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * @param string|null $type
-     *
-     * @return Email
-     */
     public function setType(?string $type): Email
     {
         $this->type = $type;

--- a/src/Customers/Entry/Phone.php
+++ b/src/Customers/Entry/Phone.php
@@ -46,19 +46,11 @@ class Phone implements Extractable, Hydratable
         ];
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Phone
-     */
     public function setId(int $id): Phone
     {
         Assert::greaterThan($id, 0);
@@ -68,19 +60,11 @@ class Phone implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getValue(): ?string
     {
         return $this->value;
     }
 
-    /**
-     * @param string|null $value
-     *
-     * @return Phone
-     */
     public function setValue(?string $value): Phone
     {
         $this->value = $value;
@@ -88,19 +72,11 @@ class Phone implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * @param string|null $type
-     *
-     * @return Phone
-     */
     public function setType(?string $type): Phone
     {
         $this->type = $type;

--- a/src/Customers/Entry/SocialProfile.php
+++ b/src/Customers/Entry/SocialProfile.php
@@ -46,19 +46,11 @@ class SocialProfile implements Extractable, Hydratable
         ];
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return SocialProfile
-     */
     public function setId(int $id): SocialProfile
     {
         Assert::greaterThan($id, 0);
@@ -68,19 +60,11 @@ class SocialProfile implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getValue(): ?string
     {
         return $this->value;
     }
 
-    /**
-     * @param string|null $value
-     *
-     * @return SocialProfile
-     */
     public function setValue(?string $value): SocialProfile
     {
         $this->value = $value;
@@ -88,19 +72,11 @@ class SocialProfile implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * @param string|null $type
-     *
-     * @return SocialProfile
-     */
     public function setType(?string $type): SocialProfile
     {
         $this->type = $type;

--- a/src/Customers/Entry/Website.php
+++ b/src/Customers/Entry/Website.php
@@ -39,19 +39,11 @@ class Website implements Extractable, Hydratable
         ];
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Website
-     */
     public function setId(int $id): Website
     {
         Assert::greaterThan($id, 0);
@@ -61,9 +53,6 @@ class Website implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getValue(): ?string
     {
         return $this->value;
@@ -71,8 +60,6 @@ class Website implements Extractable, Hydratable
 
     /**
      * @param string|null $value
-     *
-     * @return Website
      */
     public function setValue($value): Website
     {

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -18,8 +18,6 @@ abstract class Endpoint
 
     /**
      * Endpoint constructor.
-     *
-     * @param RestClient $restClient
      */
     public function __construct(RestClient $restClient)
     {
@@ -27,9 +25,6 @@ abstract class Endpoint
     }
 
     /**
-     * @param string $entityClass
-     * @param string $url
-     *
      * @return mixed
      */
     protected function loadResource(string $entityClass, string $url)
@@ -39,13 +34,6 @@ abstract class Endpoint
         return $resource->getEntity();
     }
 
-    /**
-     * @param string $entityClass
-     * @param string $rel
-     * @param string $uri
-     *
-     * @return PagedCollection
-     */
     protected function loadPage(
         string $entityClass,
         string $rel,

--- a/src/Entity/Collection.php
+++ b/src/Entity/Collection.php
@@ -14,9 +14,6 @@ class Collection extends ArrayObject implements Extractable
         parent::__construct($items);
     }
 
-    /**
-     * @return array
-     */
     public function toArray(): array
     {
         return $this->getArrayCopy();

--- a/src/Entity/LinkedEntityLoader.php
+++ b/src/Entity/LinkedEntityLoader.php
@@ -25,11 +25,6 @@ abstract class LinkedEntityLoader
      */
     private $links;
 
-    /**
-     * @param RestClient  $restClient
-     * @param HalResource $resource
-     * @param array       $links
-     */
     public function __construct(RestClient $restClient, HalResource $resource, array $links)
     {
         $this->restClient = $restClient;
@@ -46,7 +41,6 @@ abstract class LinkedEntityLoader
 
     /**
      * @param Closure|string $entityClass
-     * @param string         $rel
      *
      * @return mixed
      */
@@ -59,9 +53,6 @@ abstract class LinkedEntityLoader
 
     /**
      * @param Closure|string $entityClass
-     * @param string         $rel
-     *
-     * @return Collection
      */
     protected function loadResources($entityClass, string $rel): Collection
     {

--- a/src/Entity/PagedCollection.php
+++ b/src/Entity/PagedCollection.php
@@ -35,12 +35,6 @@ class PagedCollection extends Collection
      */
     private $loader;
 
-    /**
-     * @param array           $items
-     * @param HalPageMetadata $pageMetadata
-     * @param HalLinks        $links
-     * @param callable        $loader
-     */
     public function __construct(array $items, HalPageMetadata $pageMetadata, HalLinks $links, callable $loader)
     {
         parent::__construct($items);
@@ -50,93 +44,56 @@ class PagedCollection extends Collection
         $this->loader = $loader;
     }
 
-    /**
-     * @return int
-     */
     public function getPageNumber(): int
     {
         return $this->pageMetadata->getPageNumber();
     }
 
-    /**
-     * @return int
-     */
     public function getPageSize(): int
     {
         return $this->pageMetadata->getPageSize();
     }
 
-    /**
-     * @return int
-     */
     public function getPageElementCount(): int
     {
         return count($this);
     }
 
-    /**
-     * @return int
-     */
     public function getTotalElementCount(): int
     {
         return $this->pageMetadata->getTotalElementCount();
     }
 
-    /**
-     * @return int
-     */
     public function getTotalPageCount(): int
     {
         return $this->pageMetadata->getTotalPageCount();
     }
 
-    /**
-     * @param int $number
-     *
-     * @return self
-     */
     public function getPage(int $number): self
     {
         return $this->loadPage($this->links->expand(self::REL_PAGE, [self::PAGE_VARIABLE => $number]));
     }
 
-    /**
-     * @return self
-     */
     public function getNextPage(): self
     {
         return $this->loadPage($this->links->getHref(HalLink::REL_NEXT));
     }
 
-    /**
-     * @return self
-     */
     public function getPreviousPage(): self
     {
         return $this->loadPage($this->links->getHref(HalLink::REL_PREVIOUS));
     }
 
-    /**
-     * @return self
-     */
     public function getFirstPage(): self
     {
         return $this->loadPage($this->links->getHref(HalLink::REL_FIRST));
     }
 
-    /**
-     * @return self
-     */
     public function getLastPage(): self
     {
         return $this->loadPage($this->links->getHref(HalLink::REL_LAST));
     }
 
-    /**
-     * @param string $uri
-     *
-     * @return self
-     */
     private function loadPage(string $uri): self
     {
         return call_user_func($this->loader, $uri);

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -17,11 +17,7 @@ class ValidationErrorException extends RequestException implements Exception
     private $error;
 
     /**
-     * @param string            $message
-     * @param VndError          $error
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param \Exception|null   $previous
+     * @param string $message
      */
     public function __construct(
         $message,
@@ -38,9 +34,6 @@ class ValidationErrorException extends RequestException implements Exception
         $this->error = $error;
     }
 
-    /**
-     * @return VndError
-     */
     public function getError(): VndError
     {
         return $this->error;

--- a/src/Http/Auth/Auth.php
+++ b/src/Http/Auth/Auth.php
@@ -6,13 +6,7 @@ namespace HelpScout\Api\Http\Auth;
 
 interface Auth
 {
-    /**
-     * @return string
-     */
     public function getType(): string;
 
-    /**
-     * @return array
-     */
     public function getPayload(): array;
 }

--- a/src/Http/Auth/ClientCredentials.php
+++ b/src/Http/Auth/ClientCredentials.php
@@ -20,9 +20,6 @@ class ClientCredentials implements Auth
 
     /**
      * ClientCredentials constructor.
-     *
-     * @param string $appId
-     * @param string $appSecret
      */
     public function __construct(string $appId, string $appSecret)
     {
@@ -30,33 +27,21 @@ class ClientCredentials implements Auth
         $this->appSecret = $appSecret;
     }
 
-    /**
-     * @return string
-     */
     public function getAppId(): string
     {
         return $this->appId;
     }
 
-    /**
-     * @return string
-     */
     public function getAppSecret(): string
     {
         return $this->appSecret;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return self::TYPE;
     }
 
-    /**
-     * @return array
-     */
     public function getPayload(): array
     {
         return [

--- a/src/Http/Auth/CodeCredentials.php
+++ b/src/Http/Auth/CodeCredentials.php
@@ -25,10 +25,6 @@ class CodeCredentials implements Auth
 
     /**
      * CodeCredentials constructor.
-     *
-     * @param string $appId
-     * @param string $appSecret
-     * @param string $code
      */
     public function __construct(string $appId, string $appSecret, string $code)
     {
@@ -37,17 +33,11 @@ class CodeCredentials implements Auth
         $this->code = $code;
     }
 
-    /**
-     * @return string
-     */
     public function getAppId(): string
     {
         return $this->appId;
     }
 
-    /**
-     * @return string
-     */
     public function getAppSecret(): string
     {
         return $this->appSecret;
@@ -58,17 +48,11 @@ class CodeCredentials implements Auth
         return $this->code;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return self::TYPE;
     }
 
-    /**
-     * @return array
-     */
     public function getPayload(): array
     {
         return [

--- a/src/Http/Auth/LegacyCredentials.php
+++ b/src/Http/Auth/LegacyCredentials.php
@@ -25,9 +25,6 @@ class LegacyCredentials implements Auth
 
     /**
      * ClientCredentials constructor.
-     *
-     * @param string $clientId
-     * @param string $apiKey
      */
     public function __construct(string $clientId, string $apiKey)
     {
@@ -35,33 +32,21 @@ class LegacyCredentials implements Auth
         $this->apiKey = $apiKey;
     }
 
-    /**
-     * @return string
-     */
     public function getClientId(): string
     {
         return $this->clientId;
     }
 
-    /**
-     * @return string
-     */
     public function getApiKey(): string
     {
         return $this->apiKey;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return self::TYPE;
     }
 
-    /**
-     * @return array
-     */
     public function getPayload(): array
     {
         return [

--- a/src/Http/Auth/NullCredentials.php
+++ b/src/Http/Auth/NullCredentials.php
@@ -8,17 +8,11 @@ class NullCredentials implements Auth
 {
     public const TYPE = 'null_credentials';
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return self::TYPE;
     }
 
-    /**
-     * @return array
-     */
     public function getPayload(): array
     {
         return [];

--- a/src/Http/Auth/RefreshCredentials.php
+++ b/src/Http/Auth/RefreshCredentials.php
@@ -25,10 +25,6 @@ class RefreshCredentials implements Auth
 
     /**
      * ClientCredentials constructor.
-     *
-     * @param string $appId
-     * @param string $appSecret
-     * @param string $refreshToken
      */
     public function __construct(string $appId, string $appSecret, string $refreshToken)
     {
@@ -37,17 +33,11 @@ class RefreshCredentials implements Auth
         $this->refreshToken = $refreshToken;
     }
 
-    /**
-     * @return string
-     */
     public function getAppId(): string
     {
         return $this->appId;
     }
 
-    /**
-     * @return string
-     */
     public function getAppSecret(): string
     {
         return $this->appSecret;
@@ -58,17 +48,11 @@ class RefreshCredentials implements Auth
         return $this->refreshToken;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return self::TYPE;
     }
 
-    /**
-     * @return array
-     */
     public function getPayload(): array
     {
         return [

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -43,8 +43,7 @@ class Authenticator
     private $ttl;
 
     /**
-     * @param Client $client
-     * @param Auth   $auth
+     * @param Auth $auth
      */
     public function __construct(Client $client, Auth $auth = null)
     {
@@ -52,9 +51,6 @@ class Authenticator
         $this->auth = $auth ?? new NullCredentials();
     }
 
-    /**
-     * @return array
-     */
     public function getTokens(): array
     {
         return [
@@ -65,11 +61,6 @@ class Authenticator
         ];
     }
 
-    /**
-     * @param string $accessToken
-     *
-     * @return Authenticator
-     */
     public function setAccessToken(string $accessToken): Authenticator
     {
         $this->accessToken = $accessToken;
@@ -85,11 +76,6 @@ class Authenticator
         return $this->accessToken;
     }
 
-    /**
-     * @param string $refreshToken
-     *
-     * @return Authenticator
-     */
     public function setRefreshToken(string $refreshToken): Authenticator
     {
         $this->refreshToken = $refreshToken;
@@ -105,11 +91,6 @@ class Authenticator
         return $this->refreshToken;
     }
 
-    /**
-     * @param Client $client
-     *
-     * @return Authenticator
-     */
     public function setClient(Client $client): Authenticator
     {
         $this->client = $client;
@@ -117,9 +98,6 @@ class Authenticator
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getAuthHeader(): array
     {
         if ($this->accessToken === null) {
@@ -131,18 +109,11 @@ class Authenticator
         ];
     }
 
-    /**
-     * @return Auth
-     */
     public function getAuthCredentials(): Auth
     {
         return $this->auth;
     }
 
-    /**
-     * @param string $appId
-     * @param string $appSecret
-     */
     public function useClientCredentials(string $appId, string $appSecret): void
     {
         $this->auth = new ClientCredentials($appId, $appSecret);
@@ -155,28 +126,17 @@ class Authenticator
      * and we will remove it from the SDK.
      *
      * @deprecated
-     *
-     * @param string $clientId
-     * @param string $apiKey
      */
     public function useLegacyToken(string $clientId, string $apiKey): void
     {
         $this->auth = new LegacyCredentials($clientId, $apiKey);
     }
 
-    /**
-     * @param string $appId
-     * @param string $appSecret
-     * @param string $refreshToken
-     */
     public function useRefreshToken(string $appId, string $appSecret, string $refreshToken): void
     {
         $this->auth = new RefreshCredentials($appId, $appSecret, $refreshToken);
     }
 
-    /**
-     * @param Auth $auth
-     */
     public function setAuth(Auth $auth): void
     {
         $this->auth = $auth;
@@ -231,12 +191,6 @@ class Authenticator
         $this->ttl = $tokens['expiresIn'];
     }
 
-    /**
-     * @param array  $payload
-     * @param string $url
-     *
-     * @return array
-     */
     private function requestAuthTokens(array $payload, string $url): array
     {
         $headers = [

--- a/src/Http/Hal/HalDeserializer.php
+++ b/src/Http/Hal/HalDeserializer.php
@@ -12,11 +12,6 @@ class HalDeserializer
     const LINKS = '_links';
     const EMBEDDED = '_embedded';
 
-    /**
-     * @param string $json
-     *
-     * @return HalDocument
-     */
     public static function deserializeDocument(string $json): HalDocument
     {
         $data = json_decode($json, true);
@@ -29,9 +24,6 @@ class HalDeserializer
 
     /**
      * @param \Closure|string $entityClass
-     * @param HalDocument     $halDocument
-     *
-     * @return HalResource
      */
     public static function deserializeResource($entityClass, HalDocument $halDocument): HalResource
     {
@@ -49,10 +41,6 @@ class HalDeserializer
 
     /**
      * @param \Closure|string $entityClass
-     * @param string          $rel
-     * @param HalDocument     $halDocument
-     *
-     * @return HalResources
      */
     public static function deserializeResources($entityClass, string $rel, HalDocument $halDocument): HalResources
     {
@@ -77,11 +65,6 @@ class HalDeserializer
         return new HalResources($resources, $halDocument->getLinks());
     }
 
-    /**
-     * @param HalDocument $halDocument
-     *
-     * @return VndError
-     */
     public static function deserializeError(HalDocument $halDocument): VndError
     {
         $data = $halDocument->getData();
@@ -96,11 +79,6 @@ class HalDeserializer
         return $error;
     }
 
-    /**
-     * @param array $data
-     *
-     * @return HalDocument
-     */
     private static function createDocument(array $data): HalDocument
     {
         $links = new HalLinks();

--- a/src/Http/Hal/HalLink.php
+++ b/src/Http/Hal/HalLink.php
@@ -49,11 +49,6 @@ class HalLink
      */
     private $templated;
 
-    /**
-     * @param string $rel
-     * @param string $href
-     * @param bool   $templated
-     */
     public function __construct(string $rel, string $href, bool $templated)
     {
         $this->rel = $rel;
@@ -61,35 +56,21 @@ class HalLink
         $this->templated = $templated;
     }
 
-    /**
-     * @return string
-     */
     public function getRel(): string
     {
         return $this->rel;
     }
 
-    /**
-     * @return string
-     */
     public function getHref(): string
     {
         return $this->href;
     }
 
-    /**
-     * @return bool
-     */
     public function isTemplated(): bool
     {
         return $this->templated;
     }
 
-    /**
-     * @param array $params
-     *
-     * @return string
-     */
     public function expand(array $params): string
     {
         if (!$this->isTemplated()) {

--- a/src/Http/Hal/HalPageMetadata.php
+++ b/src/Http/Hal/HalPageMetadata.php
@@ -26,12 +26,6 @@ class HalPageMetadata
      */
     private $totalPageCount;
 
-    /**
-     * @param int $pageNumber
-     * @param int $pageSize
-     * @param int $totalElementCount
-     * @param int $totalPageCount
-     */
     public function __construct(int $pageNumber, int $pageSize, int $totalElementCount, int $totalPageCount)
     {
         $this->pageNumber = $pageNumber;
@@ -40,33 +34,21 @@ class HalPageMetadata
         $this->totalPageCount = $totalPageCount;
     }
 
-    /**
-     * @return int
-     */
     public function getPageNumber(): int
     {
         return $this->pageNumber;
     }
 
-    /**
-     * @return int
-     */
     public function getPageSize(): int
     {
         return $this->pageSize;
     }
 
-    /**
-     * @return int
-     */
     public function getTotalElementCount(): int
     {
         return $this->totalElementCount;
     }
 
-    /**
-     * @return int
-     */
     public function getTotalPageCount(): int
     {
         return $this->totalPageCount;

--- a/src/Http/Hal/HalPagedResources.php
+++ b/src/Http/Hal/HalPagedResources.php
@@ -11,11 +11,6 @@ class HalPagedResources extends HalResources
      */
     private $pageMetadata;
 
-    /**
-     * @param array           $resources
-     * @param HalLinks        $links
-     * @param HalPageMetadata $pageMetadata
-     */
     public function __construct(array $resources, HalLinks $links, HalPageMetadata $pageMetadata)
     {
         parent::__construct($resources, $links);
@@ -23,9 +18,6 @@ class HalPagedResources extends HalResources
         $this->pageMetadata = $pageMetadata;
     }
 
-    /**
-     * @return HalPageMetadata
-     */
     public function getPageMetadata(): HalPageMetadata
     {
         return $this->pageMetadata;

--- a/src/Http/Hal/HalResource.php
+++ b/src/Http/Hal/HalResource.php
@@ -17,8 +17,7 @@ class HalResource
     private $links;
 
     /**
-     * @param mixed    $entity
-     * @param HalLinks $links
+     * @param mixed $entity
      */
     public function __construct($entity, HalLinks $links)
     {
@@ -34,9 +33,6 @@ class HalResource
         return $this->entity;
     }
 
-    /**
-     * @return HalLinks
-     */
     public function getLinks(): HalLinks
     {
         return $this->links;

--- a/src/Http/Hal/HalResources.php
+++ b/src/Http/Hal/HalResources.php
@@ -18,7 +18,6 @@ class HalResources
 
     /**
      * @param HalResource[] $resources
-     * @param HalLinks      $links
      */
     public function __construct(array $resources, HalLinks $links)
     {
@@ -26,19 +25,11 @@ class HalResources
         $this->links = $links;
     }
 
-    /**
-     * @param callable $callable
-     *
-     * @return array
-     */
     public function map(callable $callable): array
     {
         return array_map($callable, $this->resources);
     }
 
-    /**
-     * @return HalLinks
-     */
     public function getLinks(): HalLinks
     {
         return $this->links;

--- a/src/Http/Hal/VndError.php
+++ b/src/Http/Hal/VndError.php
@@ -26,11 +26,6 @@ class VndError
      */
     private $errors = [];
 
-    /**
-     * @param string      $message
-     * @param string|null $logRef
-     * @param string|null $path
-     */
     public function __construct(string $message, string $logRef = null, string $path = null)
     {
         $this->message = $message;
@@ -38,9 +33,6 @@ class VndError
         $this->path = $path;
     }
 
-    /**
-     * @return string
-     */
     public function getMessage(): string
     {
         return $this->message;
@@ -95,9 +87,6 @@ class VndError
         }
     }
 
-    /**
-     * @param self $error
-     */
     public function addError(self $error)
     {
         $this->errors[] = $error;

--- a/src/Http/Handlers/ValidationHandler.php
+++ b/src/Http/Handlers/ValidationHandler.php
@@ -29,11 +29,6 @@ class ValidationHandler
         };
     }
 
-    /**
-     * @param ResponseInterface $response
-     *
-     * @return bool
-     */
     private static function isVndErrorResponse(ResponseInterface $response): bool
     {
         if (!$response->hasHeader('Content-Type')) {

--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -108,9 +108,6 @@ class RestClient
 
     /**
      * @param Closure|string $entityClass
-     * @param string         $uri
-     *
-     * @return HalResource
      */
     public function getResource($entityClass, string $uri): HalResource
     {
@@ -141,10 +138,6 @@ class RestClient
 
     /**
      * @param Closure|string $entityClass
-     * @param string         $rel
-     * @param string         $uri
-     *
-     * @return HalResources
      */
     public function getResources($entityClass, string $rel, string $uri): HalResources
     {
@@ -165,8 +158,6 @@ class RestClient
     }
 
     /**
-     * @param Request $request
-     *
      * @return mixed|ResponseInterface
      */
     private function send(Request $request)

--- a/src/Http/RestClientBuilder.php
+++ b/src/Http/RestClientBuilder.php
@@ -27,17 +27,11 @@ class RestClientBuilder
      */
     private $config;
 
-    /**
-     * @param array $config
-     */
     public function __construct(array $config = [])
     {
         $this->config = $config;
     }
 
-    /**
-     * @return RestClient
-     */
     public function build(): RestClient
     {
         return new RestClient(
@@ -46,9 +40,6 @@ class RestClientBuilder
         );
     }
 
-    /**
-     * @return Client
-     */
     protected function getGuzzleClient(): Client
     {
         $options = $this->getOptions();
@@ -56,9 +47,6 @@ class RestClientBuilder
         return new Client($options);
     }
 
-    /**
-     * @return Authenticator
-     */
     protected function getAuthenticator(): Authenticator
     {
         $authConfig = $this->config['auth'] ?? [];
@@ -69,11 +57,6 @@ class RestClientBuilder
         );
     }
 
-    /**
-     * @param array $authConfig
-     *
-     * @return Auth
-     */
     protected function getAuthClass(array $authConfig = []): Auth
     {
         $type = $authConfig['type'] ?? '';
@@ -100,9 +83,6 @@ class RestClientBuilder
         }
     }
 
-    /**
-     * @return array
-     */
     protected function getOptions(): array
     {
         return [
@@ -111,9 +91,6 @@ class RestClientBuilder
         ];
     }
 
-    /**
-     * @return HandlerStack
-     */
     protected function getHandlerStack(): HandlerStack
     {
         $handler = HandlerStack::create();

--- a/src/Mailboxes/Entry/Field.php
+++ b/src/Mailboxes/Entry/Field.php
@@ -64,19 +64,11 @@ class Field implements Hydratable
         }
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Field
-     */
     public function setId(int $id): Field
     {
         Assert::greaterThan($id, 0);
@@ -94,11 +86,6 @@ class Field implements Hydratable
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return Field
-     */
     public function setName(string $name): Field
     {
         $this->name = $name;
@@ -106,19 +93,11 @@ class Field implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @param string $type
-     *
-     * @return Field
-     */
     public function setType(string $type): Field
     {
         $this->type = $type;
@@ -126,19 +105,11 @@ class Field implements Hydratable
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getOrder(): int
     {
         return $this->order;
     }
 
-    /**
-     * @param int $order
-     *
-     * @return Field
-     */
     public function setOrder(int $order): Field
     {
         $this->order = $order;
@@ -146,19 +117,11 @@ class Field implements Hydratable
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function isRequired(): bool
     {
         return $this->required;
     }
 
-    /**
-     * @param bool $required
-     *
-     * @return Field
-     */
     public function setRequired(bool $required): Field
     {
         $this->required = $required;

--- a/src/Mailboxes/Entry/Folder.php
+++ b/src/Mailboxes/Entry/Folder.php
@@ -56,19 +56,11 @@ class Folder implements Hydratable
         $this->setUpdatedAt(new DateTime($data['updatedAt'] ?? null));
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Folder
-     */
     public function setId(int $id): Folder
     {
         Assert::greaterThan($id, 0);
@@ -78,19 +70,11 @@ class Folder implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return Folder
-     */
     public function setName(string $name): Folder
     {
         $this->name = $name;
@@ -98,19 +82,11 @@ class Folder implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @param string $type
-     *
-     * @return Folder
-     */
     public function setType(string $type): Folder
     {
         $this->type = $type;
@@ -118,19 +94,11 @@ class Folder implements Hydratable
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getUserId(): int
     {
         return $this->userId;
     }
 
-    /**
-     * @param int $userId
-     *
-     * @return Folder
-     */
     public function setUserId(int $userId): Folder
     {
         $this->userId = $userId;
@@ -138,19 +106,11 @@ class Folder implements Hydratable
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getTotalCount(): int
     {
         return $this->totalCount;
     }
 
-    /**
-     * @param int $totalCount
-     *
-     * @return Folder
-     */
     public function setTotalCount(int $totalCount): Folder
     {
         $this->totalCount = $totalCount;
@@ -158,19 +118,11 @@ class Folder implements Hydratable
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getActiveCount(): int
     {
         return $this->activeCount;
     }
 
-    /**
-     * @param int $activeCount
-     *
-     * @return Folder
-     */
     public function setActiveCount(int $activeCount): Folder
     {
         $this->activeCount = $activeCount;
@@ -178,19 +130,11 @@ class Folder implements Hydratable
         return $this;
     }
 
-    /**
-     * @return DateTime
-     */
     public function getUpdatedAt(): DateTime
     {
         return $this->updatedAt;
     }
 
-    /**
-     * @param DateTime $updatedAt
-     *
-     * @return Folder
-     */
     public function setUpdatedAt(DateTime $updatedAt): Folder
     {
         $this->updatedAt = $updatedAt;

--- a/src/Mailboxes/Mailbox.php
+++ b/src/Mailboxes/Mailbox.php
@@ -71,9 +71,6 @@ class Mailbox implements Hydratable
         $this->setEmail($data['email'] ?? null);
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;
@@ -100,8 +97,6 @@ class Mailbox implements Hydratable
     }
 
     /**
-     * @param DateTime|null $createdAt
-     *
      * @return Mailbox
      */
     public function setCreatedAt(DateTime $createdAt = null): self
@@ -120,8 +115,6 @@ class Mailbox implements Hydratable
     }
 
     /**
-     * @param DateTime|null $updatedAt
-     *
      * @return Mailbox
      */
     public function setUpdatedAt(DateTime $updatedAt = null): self

--- a/src/Mailboxes/MailboxRequest.php
+++ b/src/Mailboxes/MailboxRequest.php
@@ -13,9 +13,6 @@ class MailboxRequest
      */
     private $links = [];
 
-    /**
-     * @param array $links
-     */
     public function __construct(array $links = [])
     {
         foreach ($links as $link) {
@@ -23,17 +20,11 @@ class MailboxRequest
         }
     }
 
-    /**
-     * @return array
-     */
     public function getLinks(): array
     {
         return $this->links;
     }
 
-    /**
-     * @param string $link
-     */
     private function addLink(string $link)
     {
         Assert::oneOf($link, [
@@ -44,37 +35,21 @@ class MailboxRequest
         $this->links[] = $link;
     }
 
-    /**
-     * @param string $rel
-     *
-     * @return bool
-     */
     public function hasLink(string $rel): bool
     {
         return in_array($rel, $this->links, true);
     }
 
-    /**
-     * @return self
-     */
     public function withFields(): self
     {
         return $this->with(MailboxLinks::FIELDS);
     }
 
-    /**
-     * @return self
-     */
     public function withFolders(): self
     {
         return $this->with(MailboxLinks::FOLDERS);
     }
 
-    /**
-     * @param string $link
-     *
-     * @return self
-     */
     private function with(string $link): self
     {
         $request = clone $this;

--- a/src/Mailboxes/MailboxesEndpoint.php
+++ b/src/Mailboxes/MailboxesEndpoint.php
@@ -28,8 +28,6 @@ class MailboxesEndpoint extends Endpoint
     }
 
     /**
-     * @param MailboxRequest|null $mailboxRequest
-     *
      * @return Mailbox[]|PagedCollection
      */
     public function list(MailboxRequest $mailboxRequest = null): PagedCollection
@@ -41,9 +39,6 @@ class MailboxesEndpoint extends Endpoint
     }
 
     /**
-     * @param string         $uri
-     * @param MailboxRequest $mailboxRequest
-     *
      * @return Mailbox[]|PagedCollection
      */
     private function loadMailboxes(string $uri, MailboxRequest $mailboxRequest): PagedCollection
@@ -64,12 +59,6 @@ class MailboxesEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param HalResource    $mailboxResource
-     * @param MailboxRequest $mailboxRequest
-     *
-     * @return Mailbox
-     */
     private function hydrateMailboxWithSubEntities(
         HalResource $mailboxResource,
         MailboxRequest $mailboxRequest

--- a/src/Reports/ParameterBag.php
+++ b/src/Reports/ParameterBag.php
@@ -13,17 +13,12 @@ class ParameterBag
 
     /**
      * ParameterBag constructor.
-     *
-     * @param array $params
      */
     public function __construct(array $params)
     {
         $this->params = $params;
     }
 
-    /**
-     * @return array
-     */
     public function getParams(): array
     {
         return $this->params;

--- a/src/Reports/ParameterBagFactory.php
+++ b/src/Reports/ParameterBagFactory.php
@@ -23,9 +23,6 @@ class ParameterBagFactory
 
     /**
      * ParameterBagFactory constructor.
-     *
-     * @param array $fields
-     * @param array $params
      */
     public function __construct(array $fields, array $params)
     {
@@ -34,9 +31,6 @@ class ParameterBagFactory
         $this->prepareFields();
     }
 
-    /**
-     * @return ParameterBag
-     */
     public function build(): ParameterBag
     {
         return new ParameterBag($this->params);
@@ -53,8 +47,7 @@ class ParameterBagFactory
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
+     * @param mixed $value
      */
     private function prepareField(string $field, $value): void
     {
@@ -82,8 +75,7 @@ class ParameterBagFactory
     }
 
     /**
-     * @param string $field
-     * @param mixed  $date
+     * @param mixed $date
      */
     private function formatDateInterval(string $field, $date): void
     {
@@ -95,8 +87,7 @@ class ParameterBagFactory
     }
 
     /**
-     * @param string $field
-     * @param mixed  $values
+     * @param mixed $values
      */
     private function formatArray(string $field, $values): void
     {

--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -17,25 +17,17 @@ abstract class Report
 
     /**
      * Report constructor.
-     *
-     * @param ParameterBag $params
      */
     public function __construct(ParameterBag $params)
     {
         $this->params = $params;
     }
 
-    /**
-     * @return string
-     */
     public function getQuery(): string
     {
         return \http_build_query($this->params->getParams());
     }
 
-    /**
-     * @return string
-     */
     public function getUriPath(): string
     {
         return sprintf(
@@ -45,11 +37,6 @@ abstract class Report
         );
     }
 
-    /**
-     * @param array $params
-     *
-     * @return Report
-     */
     public static function getInstance(array $params): Report
     {
         $fields = static::QUERY_FIELDS;

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -10,8 +10,6 @@ namespace HelpScout\Api\Support;
 class Filesystem
 {
     /**
-     * @param string $path
-     *
      * @return bool|string
      */
     public function contents(string $path)
@@ -20,8 +18,6 @@ class Filesystem
     }
 
     /**
-     * @param string $path
-     *
      * @return bool|string
      */
     public function mimeType(string $path)

--- a/src/Tags/Tag.php
+++ b/src/Tags/Tag.php
@@ -162,9 +162,6 @@ class Tag implements Extractable, Hydratable
         return $this->slug;
     }
 
-    /**
-     * @return \DateTime|null
-     */
     public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
@@ -182,9 +179,6 @@ class Tag implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return \DateTime|null
-     */
     public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
@@ -202,17 +196,12 @@ class Tag implements Extractable, Hydratable
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getTicketCount(): ?int
     {
         return $this->ticketCount;
     }
 
     /**
-     * @param int|null $ticketCount
-     *
      * @return Tag
      */
     public function setTicketCount(?int $ticketCount): self

--- a/src/Tags/TagsEndpoint.php
+++ b/src/Tags/TagsEndpoint.php
@@ -12,9 +12,6 @@ class TagsEndpoint extends Endpoint
     public const LIST_TAGS_URI = '/v2/tags';
     public const RESOURCE_KEY = 'tags';
 
-    /**
-     * @return PagedCollection
-     */
     public function list(): PagedCollection
     {
         return $this->loadPage(

--- a/src/Teams/Team.php
+++ b/src/Teams/Team.php
@@ -67,19 +67,11 @@ class Team implements Hydratable
         $this->setInitials($data['initials'] ?? null);
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @param int|null $id
-     *
-     * @return Team
-     */
     public function setId(?int $id): Team
     {
         $this->id = $id;
@@ -87,9 +79,6 @@ class Team implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getName(): ?string
     {
         return $this->name;
@@ -97,8 +86,6 @@ class Team implements Hydratable
 
     /**
      * @param string|null $name
-     *
-     * @return Team
      */
     public function setName($name): Team
     {
@@ -107,9 +94,6 @@ class Team implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTimezone(): ?string
     {
         return $this->timezone;
@@ -117,8 +101,6 @@ class Team implements Hydratable
 
     /**
      * @param string|null $timezone
-     *
-     * @return Team
      */
     public function setTimezone($timezone): Team
     {
@@ -127,9 +109,6 @@ class Team implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPhotoUrl(): ?string
     {
         return $this->photoUrl;
@@ -137,8 +116,6 @@ class Team implements Hydratable
 
     /**
      * @param string|null $photoUrl
-     *
-     * @return Team
      */
     public function setPhotoUrl($photoUrl): Team
     {
@@ -147,9 +124,6 @@ class Team implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getMention(): ?string
     {
         return $this->mention;
@@ -157,8 +131,6 @@ class Team implements Hydratable
 
     /**
      * @param string|null $mention
-     *
-     * @return Team
      */
     public function setMention($mention): Team
     {
@@ -167,9 +139,6 @@ class Team implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getInitials(): ?string
     {
         return $this->initials;
@@ -177,8 +146,6 @@ class Team implements Hydratable
 
     /**
      * @param string|null $initials
-     *
-     * @return Team
      */
     public function setInitials($initials): Team
     {
@@ -187,19 +154,11 @@ class Team implements Hydratable
         return $this;
     }
 
-    /**
-     * @return DateTime|null
-     */
     public function getCreatedAt(): ?DateTime
     {
         return $this->createdAt;
     }
 
-    /**
-     * @param DateTime|null $createdAt
-     *
-     * @return Team
-     */
     public function setCreatedAt(DateTime $createdAt = null): Team
     {
         $this->createdAt = $createdAt;
@@ -207,19 +166,11 @@ class Team implements Hydratable
         return $this;
     }
 
-    /**
-     * @return DateTime|null
-     */
     public function getUpdatedAt(): ?DateTime
     {
         return $this->updatedAt;
     }
 
-    /**
-     * @param DateTime|null $updatedAt
-     *
-     * @return Team
-     */
     public function setUpdatedAt(DateTime $updatedAt = null): Team
     {
         $this->updatedAt = $updatedAt;

--- a/src/Teams/TeamsEndpoint.php
+++ b/src/Teams/TeamsEndpoint.php
@@ -31,8 +31,6 @@ class TeamsEndpoint extends Endpoint
     /**
      * Get the members of a team.
      *
-     * @param int $teamId
-     *
      * @return User[]|PagedCollection
      */
     public function members(int $teamId): PagedCollection

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -104,19 +104,11 @@ class User implements Hydratable
         $this->setInitials($data['initials'] ?? null);
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @param int|null $id
-     *
-     * @return User
-     */
     public function setId(?int $id): User
     {
         Assert::greaterThan($id, 0);
@@ -126,19 +118,11 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return DateTime|null
-     */
     public function getCreatedAt(): ?DateTime
     {
         return $this->createdAt;
     }
 
-    /**
-     * @param DateTime|null $createdAt
-     *
-     * @return User
-     */
     public function setCreatedAt(DateTime $createdAt = null): User
     {
         $this->createdAt = $createdAt;
@@ -146,19 +130,11 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return DateTime|null
-     */
     public function getUpdatedAt(): ?DateTime
     {
         return $this->updatedAt;
     }
 
-    /**
-     * @param DateTime|null $updatedAt
-     *
-     * @return User
-     */
     public function setUpdatedAt(DateTime $updatedAt = null): User
     {
         $this->updatedAt = $updatedAt;
@@ -166,9 +142,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFirstName(): ?string
     {
         return $this->firstName;
@@ -176,8 +149,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $firstName
-     *
-     * @return User
      */
     public function setFirstName($firstName): User
     {
@@ -186,9 +157,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getLastName(): ?string
     {
         return $this->lastName;
@@ -196,8 +164,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $lastName
-     *
-     * @return User
      */
     public function setLastName($lastName): User
     {
@@ -206,9 +172,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getEmail(): ?string
     {
         return $this->email;
@@ -216,8 +179,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $email
-     *
-     * @return User
      */
     public function setEmail($email): User
     {
@@ -226,9 +187,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getRole(): ?string
     {
         return $this->role;
@@ -236,8 +194,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $role
-     *
-     * @return User
      */
     public function setRole($role): User
     {
@@ -246,9 +202,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTimezone(): ?string
     {
         return $this->timezone;
@@ -256,8 +209,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $timezone
-     *
-     * @return User
      */
     public function setTimezone($timezone): User
     {
@@ -266,9 +217,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPhotoUrl(): ?string
     {
         return $this->photoUrl;
@@ -276,8 +224,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $photoUrl
-     *
-     * @return User
      */
     public function setPhotoUrl($photoUrl): User
     {
@@ -286,9 +232,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
@@ -296,8 +239,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $type
-     *
-     * @return User
      */
     public function setType($type): User
     {
@@ -306,9 +247,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getMention(): ?string
     {
         return $this->mention;
@@ -316,8 +254,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $mention
-     *
-     * @return User
      */
     public function setMention($mention): User
     {
@@ -326,9 +262,6 @@ class User implements Hydratable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getInitials(): ?string
     {
         return $this->initials;
@@ -336,8 +269,6 @@ class User implements Hydratable
 
     /**
      * @param string|null $initials
-     *
-     * @return User
      */
     public function setInitials($initials): User
     {

--- a/src/Webhooks/IncomingWebhook.php
+++ b/src/Webhooks/IncomingWebhook.php
@@ -40,9 +40,6 @@ class IncomingWebhook
 
     /**
      * IncomingWebhook constructor.
-     *
-     * @param RequestInterface $request
-     * @param string           $secret
      */
     public function __construct(RequestInterface $request, string $secret)
     {
@@ -84,9 +81,6 @@ class IncomingWebhook
         }
     }
 
-    /**
-     * @return string
-     */
     protected function generateSignature(): string
     {
         $body = $this->getJson();
@@ -101,11 +95,6 @@ class IncomingWebhook
         );
     }
 
-    /**
-     * @param array $headers
-     *
-     * @return string
-     */
     protected function findHeader(array $headers): string
     {
         $signature = '';
@@ -123,35 +112,21 @@ class IncomingWebhook
         return $signature;
     }
 
-    /**
-     * @return bool
-     */
     public function isTestEvent(): bool
     {
         return $this->findHeader(self::EVENT_HEADERS) === self::TEST_EVENT;
     }
 
-    /**
-     * @return bool
-     */
     public function isConversationEvent(): bool
     {
         return $this->isEventTypeOf('convo');
     }
 
-    /**
-     * @return bool
-     */
     public function isCustomerEvent(): bool
     {
         return $this->isEventTypeOf('customer');
     }
 
-    /**
-     * @param string $eventType
-     *
-     * @return bool
-     */
     protected function isEventTypeOf(string $eventType): bool
     {
         $header = $this->getEventType();
@@ -159,17 +134,11 @@ class IncomingWebhook
         return strpos($header, $eventType) === 0;
     }
 
-    /**
-     * @return string
-     */
     public function getEventType(): string
     {
         return $this->findHeader(self::EVENT_HEADERS);
     }
 
-    /**
-     * @return array
-     */
     public function getDataArray(): array
     {
         return \json_decode(
@@ -178,9 +147,6 @@ class IncomingWebhook
         );
     }
 
-    /**
-     * @return \stdClass
-     */
     public function getDataObject(): \stdClass
     {
         return \json_decode(
@@ -188,17 +154,12 @@ class IncomingWebhook
         );
     }
 
-    /**
-     * @return string
-     */
     public function getJson(): string
     {
         return (string) $this->request->getBody();
     }
 
     /**
-     * @return Conversation
-     *
      * @throws JsonException
      */
     public function getConversation(): Conversation
@@ -214,8 +175,6 @@ class IncomingWebhook
     }
 
     /**
-     * @return Customer
-     *
      * @throws JsonException
      */
     public function getCustomer(): Customer

--- a/src/Webhooks/Webhook.php
+++ b/src/Webhooks/Webhook.php
@@ -58,10 +58,6 @@ class Webhook implements Hydratable, Extractable
      */
     private $secret;
 
-    /**
-     * @param array $data
-     * @param array $embedded
-     */
     public function hydrate(array $data, array $embedded = []): void
     {
         $this->setId($data['id'] ?? null);
@@ -71,9 +67,6 @@ class Webhook implements Hydratable, Extractable
         $this->setSecret($data['secret'] ?? null);
     }
 
-    /**
-     * @return array
-     */
     public function extract(): array
     {
         return [
@@ -85,19 +78,11 @@ class Webhook implements Hydratable, Extractable
         ];
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int|null $id
-     *
-     * @return Webhook
-     */
     public function setId(?int $id): Webhook
     {
         $this->id = $id;
@@ -113,11 +98,6 @@ class Webhook implements Hydratable, Extractable
         return $this->state;
     }
 
-    /**
-     * @param string|null $state
-     *
-     * @return Webhook
-     */
     public function setState(?string $state): Webhook
     {
         if (null !== $state) {
@@ -129,19 +109,11 @@ class Webhook implements Hydratable, Extractable
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getEvents(): array
     {
         return $this->events;
     }
 
-    /**
-     * @param array $events
-     *
-     * @return Webhook
-     */
     public function setEvents(array $events = []): Webhook
     {
         $validEvents = array_values(
@@ -165,8 +137,6 @@ class Webhook implements Hydratable, Extractable
 
     /**
      * @param string $url
-     *
-     * @return Webhook
      */
     public function setUrl(?string $url): Webhook
     {
@@ -185,8 +155,6 @@ class Webhook implements Hydratable, Extractable
 
     /**
      * @param string $secret
-     *
-     * @return Webhook
      */
     public function setSecret(?string $secret): Webhook
     {

--- a/src/Webhooks/WebhooksEndpoint.php
+++ b/src/Webhooks/WebhooksEndpoint.php
@@ -16,11 +16,6 @@ class WebhooksEndpoint extends Endpoint
     public const DELETE_WEBHOOK_URI = '/v2/webhooks/%d';
     public const RESOURCE_KEY = 'webhooks';
 
-    /**
-     * @param Webhook $webhook
-     *
-     * @return int
-     */
     public function create(Webhook $webhook): int
     {
         return $this->restClient->createResource(
@@ -29,11 +24,6 @@ class WebhooksEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param int $id
-     *
-     * @return Webhook
-     */
     public function get(int $id): Webhook
     {
         return $this->loadResource(
@@ -54,9 +44,6 @@ class WebhooksEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @param Webhook $webhook
-     */
     public function update(Webhook $webhook): void
     {
         $this->restClient
@@ -66,9 +53,6 @@ class WebhooksEndpoint extends Endpoint
             );
     }
 
-    /**
-     * @param int $webhookId
-     */
     public function delete(int $webhookId): void
     {
         $this->restClient->deleteResource(

--- a/src/Workflows/RunWorkflowRequest.php
+++ b/src/Workflows/RunWorkflowRequest.php
@@ -15,8 +15,6 @@ class RunWorkflowRequest
 
     /**
      * RunWorkflowRequest constructor.
-     *
-     * @param array $conversations
      */
     public function __construct(array $conversations = [])
     {

--- a/src/Workflows/Workflow.php
+++ b/src/Workflows/Workflow.php
@@ -62,10 +62,6 @@ class Workflow implements Hydratable, Extractable
      */
     private $modifiedAt;
 
-    /**
-     * @param array $data
-     * @param array $embedded
-     */
     public function hydrate(array $data, array $embedded = [])
     {
         $this->setId($data['id'] ?? null);
@@ -78,9 +74,6 @@ class Workflow implements Hydratable, Extractable
         $this->setModifiedAt($data['modifiedAt'] ?? null);
     }
 
-    /**
-     * @return array
-     */
     public function extract(): array
     {
         $data = [
@@ -103,19 +96,11 @@ class Workflow implements Hydratable, Extractable
         return $data;
     }
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int|null $id
-     *
-     * @return Workflow
-     */
     public function setId(?int $id): Workflow
     {
         $this->id = $id;
@@ -123,19 +108,11 @@ class Workflow implements Hydratable, Extractable
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getMailboxId(): ?int
     {
         return $this->mailboxId;
     }
 
-    /**
-     * @param int|null $mailboxId
-     *
-     * @return Workflow
-     */
     public function setMailboxId(?int $mailboxId): Workflow
     {
         $this->mailboxId = $mailboxId;
@@ -143,19 +120,11 @@ class Workflow implements Hydratable, Extractable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * @param string|null $type
-     *
-     * @return Workflow
-     */
     public function setType(?string $type): Workflow
     {
         if ($type !== null) {
@@ -186,19 +155,11 @@ class Workflow implements Hydratable, Extractable
         return $this->setType(self::TYPE_AUTOMATIC);
     }
 
-    /**
-     * @return string|null
-     */
     public function getStatus(): ?string
     {
         return $this->status;
     }
 
-    /**
-     * @param string|null $status
-     *
-     * @return Workflow
-     */
     public function setStatus(?string $status): Workflow
     {
         $this->status = $status;
@@ -206,19 +167,11 @@ class Workflow implements Hydratable, Extractable
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getOrder(): ?int
     {
         return $this->order;
     }
 
-    /**
-     * @param int|null $order
-     *
-     * @return Workflow
-     */
     public function setOrder(?int $order): Workflow
     {
         $this->order = $order;
@@ -226,19 +179,11 @@ class Workflow implements Hydratable, Extractable
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getName(): ?string
     {
         return $this->name;
     }
 
-    /**
-     * @param string|null $name
-     *
-     * @return Workflow
-     */
     public function setName(?string $name): Workflow
     {
         $this->name = $name;
@@ -246,9 +191,6 @@ class Workflow implements Hydratable, Extractable
         return $this;
     }
 
-    /**
-     * @return \DateTime|null
-     */
     public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
@@ -256,8 +198,6 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param string|null $createdAt
-     *
-     * @return Workflow
      */
     public function setCreatedAt($createdAt): Workflow
     {
@@ -266,9 +206,6 @@ class Workflow implements Hydratable, Extractable
         return $this;
     }
 
-    /**
-     * @return \DateTime|null
-     */
     public function getModifiedAt(): ?\DateTime
     {
         return $this->modifiedAt;
@@ -276,8 +213,6 @@ class Workflow implements Hydratable, Extractable
 
     /**
      * @param string|null $modifiedAt
-     *
-     * @return Workflow
      */
     public function setModifiedAt($modifiedAt): Workflow
     {

--- a/src/Workflows/WorkflowBatch.php
+++ b/src/Workflows/WorkflowBatch.php
@@ -15,17 +15,12 @@ class WorkflowBatch implements Extractable
 
     /**
      * WorkflowBatch constructor.
-     *
-     * @param array $conversations
      */
     public function __construct(array $conversations = [])
     {
         $this->conversations = $conversations;
     }
 
-    /**
-     * @return array
-     */
     public function extract(): array
     {
         return [

--- a/src/Workflows/WorkflowsEndpoint.php
+++ b/src/Workflows/WorkflowsEndpoint.php
@@ -22,9 +22,6 @@ class WorkflowsEndpoint extends Endpoint
 
     /**
      * Run a manual workflow on a list of conversations.
-     *
-     * @param int   $workflowId
-     * @param array $convos
      */
     public function runWorkflow(int $workflowId, array $convos): void
     {
@@ -56,9 +53,6 @@ class WorkflowsEndpoint extends Endpoint
         );
     }
 
-    /**
-     * @return PagedCollection
-     */
     public function list(): PagedCollection
     {
         return $this->loadPage(

--- a/tests/ApiClientIntegrationTestCase.php
+++ b/tests/ApiClientIntegrationTestCase.php
@@ -62,9 +62,6 @@ abstract class ApiClientIntegrationTestCase extends TestCase
         );
     }
 
-    /**
-     * @param array $responses
-     */
     protected function stubResponses(array $responses): void
     {
         foreach ($responses as $response) {
@@ -72,9 +69,6 @@ abstract class ApiClientIntegrationTestCase extends TestCase
         }
     }
 
-    /**
-     * @param Response $response
-     */
     protected function stubResponse(Response $response): void
     {
         $this->mockHandler->append($response);
@@ -84,8 +78,6 @@ abstract class ApiClientIntegrationTestCase extends TestCase
      * @param int    $status
      * @param string $body
      * @param array  $headers
-     *
-     * @return Response
      */
     protected function getResponse($status = 200, $body = '', $headers = []): Response
     {

--- a/tests/Payloads/CustomerPayloads.php
+++ b/tests/Payloads/CustomerPayloads.php
@@ -6,22 +6,11 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class CustomerPayloads
 {
-    /**
-     * @param int $id
-     *
-     * @return string
-     */
     public static function getCustomer(int $id): string
     {
         return json_encode(static::customer($id));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getCustomers(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -71,11 +60,6 @@ class CustomerPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function customer(int $id): array
     {
         return [
@@ -118,11 +102,6 @@ class CustomerPayloads
         ];
     }
 
-    /**
-     * @param int $customerId
-     *
-     * @return string
-     */
     public static function getAddress(int $customerId): string
     {
         return json_encode([
@@ -139,11 +118,6 @@ class CustomerPayloads
         ]);
     }
 
-    /**
-     * @param int $customerId
-     *
-     * @return string
-     */
     public static function getChats(int $customerId): string
     {
         return json_encode([
@@ -169,11 +143,6 @@ class CustomerPayloads
         ]);
     }
 
-    /**
-     * @param int $customerId
-     *
-     * @return string
-     */
     public static function getEmails(int $customerId): string
     {
         return json_encode([
@@ -199,11 +168,6 @@ class CustomerPayloads
         ]);
     }
 
-    /**
-     * @param int $customerId
-     *
-     * @return string
-     */
     public static function getPhones(int $customerId): string
     {
         return json_encode([
@@ -229,11 +193,6 @@ class CustomerPayloads
         ]);
     }
 
-    /**
-     * @param int $customerId
-     *
-     * @return string
-     */
     public static function getSocialProfiles(int $customerId): string
     {
         return json_encode([
@@ -259,11 +218,6 @@ class CustomerPayloads
         ]);
     }
 
-    /**
-     * @param int $customerId
-     *
-     * @return string
-     */
     public static function getWebsites(int $customerId): string
     {
         return json_encode([

--- a/tests/Payloads/ErrorPayloads.php
+++ b/tests/Payloads/ErrorPayloads.php
@@ -6,9 +6,6 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class ErrorPayloads
 {
-    /**
-     * @return string
-     */
     public static function validationErrors(): string
     {
         return json_encode([
@@ -37,9 +34,6 @@ class ErrorPayloads
         ]);
     }
 
-    /**
-     * @return string
-     */
     public static function internalServerError(): string
     {
         return json_encode([
@@ -54,9 +48,6 @@ class ErrorPayloads
         ]);
     }
 
-    /**
-     * @return string
-     */
     public static function rateLimitExceededError(): string
     {
         return json_encode([

--- a/tests/Payloads/MailboxPayloads.php
+++ b/tests/Payloads/MailboxPayloads.php
@@ -8,22 +8,11 @@ use HelpScout\Api\Mailboxes\Entry\Field;
 
 class MailboxPayloads
 {
-    /**
-     * @param int $id
-     *
-     * @return string
-     */
     public static function getMailbox(int $id): string
     {
         return json_encode(static::mailbox($id));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getMailboxes(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -73,11 +62,6 @@ class MailboxPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function mailbox(int $id): array
     {
         return [
@@ -101,11 +85,6 @@ class MailboxPayloads
         ];
     }
 
-    /**
-     * @param int $mailboxId
-     *
-     * @return string
-     */
     public static function getFields(int $mailboxId): string
     {
         return json_encode([
@@ -145,11 +124,6 @@ class MailboxPayloads
         ]);
     }
 
-    /**
-     * @param int $mailboxId
-     *
-     * @return string
-     */
     public static function getFolders(int $mailboxId): string
     {
         return json_encode([

--- a/tests/Payloads/TagPayloads.php
+++ b/tests/Payloads/TagPayloads.php
@@ -6,20 +6,11 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class TagPayloads
 {
-    /**
-     * @return string
-     */
     public static function getTag(): string
     {
         return json_encode(static::tag(1));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getTags(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -69,11 +60,6 @@ class TagPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function tag(int $id): array
     {
         return [

--- a/tests/Payloads/TeamPayloads.php
+++ b/tests/Payloads/TeamPayloads.php
@@ -6,22 +6,11 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class TeamPayloads
 {
-    /**
-     * @param int $id
-     *
-     * @return string
-     */
     public static function getTeam(int $id): string
     {
         return json_encode(static::team($id));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getTeams(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -71,11 +60,6 @@ class TeamPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function team(int $id): array
     {
         return [

--- a/tests/Payloads/ThreadPayloads.php
+++ b/tests/Payloads/ThreadPayloads.php
@@ -6,22 +6,11 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class ThreadPayloads
 {
-    /**
-     * @param int $id
-     *
-     * @return string
-     */
     public static function getThread(int $id): string
     {
         return json_encode(static::thread($id));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getThreads(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -71,11 +60,6 @@ class ThreadPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function thread(int $id): array
     {
         return [

--- a/tests/Payloads/UserPayloads.php
+++ b/tests/Payloads/UserPayloads.php
@@ -6,22 +6,11 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class UserPayloads
 {
-    /**
-     * @param int $id
-     *
-     * @return string
-     */
     public static function getUser(int $id): string
     {
         return json_encode(static::user($id));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getUsers(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -71,11 +60,6 @@ class UserPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function user(int $id): array
     {
         return [

--- a/tests/Payloads/WebhookPayloads.php
+++ b/tests/Payloads/WebhookPayloads.php
@@ -6,22 +6,11 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class WebhookPayloads
 {
-    /**
-     * @param int $id
-     *
-     * @return string
-     */
     public static function getWebhook(int $id): string
     {
         return json_encode(static::webhook($id));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getWebhooks(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -71,11 +60,6 @@ class WebhookPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function webhook(int $id): array
     {
         return [

--- a/tests/Payloads/WorkflowPayloads.php
+++ b/tests/Payloads/WorkflowPayloads.php
@@ -6,22 +6,11 @@ namespace HelpScout\Api\Tests\Payloads;
 
 class WorkflowPayloads
 {
-    /**
-     * @param int $id
-     *
-     * @return string
-     */
     public static function getWebhook(int $id): string
     {
         return json_encode(static::workflow($id));
     }
 
-    /**
-     * @param int $pageNumber
-     * @param int $totalElements
-     *
-     * @return string
-     */
     public static function getWorkflows(int $pageNumber, int $totalElements): string
     {
         $pageSize = 10;
@@ -71,11 +60,6 @@ class WorkflowPayloads
         return json_encode($data);
     }
 
-    /**
-     * @param int $id
-     *
-     * @return array
-     */
     private static function workflow(int $id): array
     {
         return [

--- a/tests/ReflectionTestTrait.php
+++ b/tests/ReflectionTestTrait.php
@@ -7,9 +7,7 @@ namespace HelpScout\Api\Tests;
 trait ReflectionTestTrait
 {
     /**
-     * @param mixed  $object
-     * @param string $method
-     * @param array  $parameters
+     * @param mixed $object
      *
      * @return mixed
      *
@@ -27,8 +25,7 @@ trait ReflectionTestTrait
     }
 
     /**
-     * @param mixed  $object
-     * @param string $attributeName
+     * @param mixed $object
      *
      * @return mixed
      *
@@ -44,9 +41,8 @@ trait ReflectionTestTrait
     }
 
     /**
-     * @param mixed  $object
-     * @param string $attributeName
-     * @param mixed  $value
+     * @param mixed $object
+     * @param mixed $value
      *
      * @throws \ReflectionException
      */
@@ -61,8 +57,6 @@ trait ReflectionTestTrait
 
     /**
      * @param mixed $object
-     *
-     * @return string
      */
     protected function getClassName(&$object): string
     {
@@ -76,8 +70,6 @@ trait ReflectionTestTrait
     /**
      * getFullMock.
      *
-     * @param string $name
-     *
      * @return mixed
      */
     public function getFullMock(string $name)
@@ -89,9 +81,6 @@ trait ReflectionTestTrait
 
     /**
      * getPartialMock.
-     *
-     * @param string $name
-     * @param array  $methods
      *
      * @return mixed
      */

--- a/tests/Reports/ReportTest.php
+++ b/tests/Reports/ReportTest.php
@@ -44,8 +44,6 @@ class ReportTest extends TestCase
 
     /**
      * @dataProvider reportTypeProvider
-     *
-     * @param string $reportName
      */
     public function testGetInstances(string $reportName)
     {


### PR DESCRIPTION
When creating https://github.com/helpscout/helpscout-api-php/pull/206 I noticed that our most recent shared styling updates haven't been applied to this project and thus changes are failing due to excessive doc blocks.  This PR strips out all doc blocks that aren't needed due to strong typehints.  There are only changes to docblocks, no code changes.