### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,9 +559,12 @@ Create a new conversation, as if the customer sent an email to your mailbox.
 
 ```php
 
+$email = new Email();
+$email->setValue('my-customer@company.com');
+
 // We can specify either the id or email for the Customer
 $customer = new Customer();
-$customer->addEmail('my-customer@company.com');
+$customer->addEmail($email);
 
 $thread = new CustomerThread();
 $thread->setCustomer($customer);


### PR DESCRIPTION
It looks like the documentation is incorrect/outdated. When running `$customer->addEmail('my-customer@company.com');` on v2.0.0, I get the error:

`Argument 1 passed to HelpScout\Api\Customers\Customer::addEmail() must be an instance of HelpScout\Api\Customers\Entry\Email, string given`

This PR updates the documentation to pass `addEmail` an `Email` object.