### PR TITLE
Require PHP 7.3 and upgrade PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
 language: php
 
 php:
-  - 7.2
   - 7.3
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ql/uri-template": "^1.1",
         "webmozart/assert": "^1.2",
         "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.4",
         "phpstan/phpstan": "^0.10.1",
         "friendsofphp/php-cs-fixer": "^2.3",
         "mockery/mockery": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ql/uri-template": "^1.1",
         "webmozart/assert": "^1.2",
         "guzzlehttp/guzzle": "^6.3"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,3 @@ parameters:
         # Ignore type errors for passing a Mock
         - '#.*MockObject given.*#'
         - '#.*MockInterface given.*#'
-        - '#.*does not accept PHPUnit\\Framework\\MockObject\\MockObject.*#'

--- a/tests/ApiClientIntegrationTestCase.php
+++ b/tests/ApiClientIntegrationTestCase.php
@@ -40,7 +40,7 @@ abstract class ApiClientIntegrationTestCase extends TestCase
      */
     protected $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->history = [];
         $this->mockHandler = new MockHandler();
@@ -74,12 +74,7 @@ abstract class ApiClientIntegrationTestCase extends TestCase
         $this->mockHandler->append($response);
     }
 
-    /**
-     * @param int    $status
-     * @param string $body
-     * @param array  $headers
-     */
-    protected function getResponse($status = 200, $body = '', $headers = []): Response
+    protected function getResponse(int $status = 200, string $body = '', array $headers = []): Response
     {
         return new Response($status, $headers, $body);
     }

--- a/tests/ApiClientTest.php
+++ b/tests/ApiClientTest.php
@@ -38,7 +38,7 @@ class ApiClientTest extends TestCase
      */
     private $guzzle;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->authenticator = Mockery::mock(Authenticator::class);
         $this->guzzle = Mockery::mock(Client::class);

--- a/tests/Authentication/AuthenticationIntegrationTest.php
+++ b/tests/Authentication/AuthenticationIntegrationTest.php
@@ -21,7 +21,7 @@ class AuthenticationIntegrationTest extends ApiClientIntegrationTestCase
 {
     protected $guzzle;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -248,7 +248,9 @@ class ConversationTest extends TestCase
         );
         $conversation->setCustomerWaitingSince($customerWaitingSince);
 
-        $this->assertArraySubset([
+        $extractedConversation = $conversation->extract();
+
+        $firstLevelValues = [
             'id' => 12,
             'number' => 3526,
             'threadCount' => 2,
@@ -262,49 +264,77 @@ class ConversationTest extends TestCase
             'subject' => 'Help',
             'preview' => 'Preview',
             'mailboxId' => 13,
-            'assignee' => [
-                'id' => 9865,
-                'firstName' => 'Mr',
-                'lastName' => 'Robot',
-            ],
-            'createdBy' => [
-                'id' => 12,
-                'type' => 'customer',
-            ],
             'createdAt' => '2017-04-21T14:39:56Z',
             'closedAt' => '2017-04-21T12:23:06Z',
             'closedBy' => 14,
             'userUpdatedAt' => '2017-04-21T03:12:06Z',
-            'source' => [
+        ];
+
+        $this->assertEquals(
+            $firstLevelValues,
+            array_intersect_assoc($extractedConversation, $firstLevelValues)
+        );
+
+        $this->assertEquals(
+            [
+                'id' => 9865,
+                'firstName' => 'Mr',
+                'lastName' => 'Robot',
+            ],
+            $extractedConversation['assignee']
+        );
+
+        $this->assertEquals(
+            [
+                'id' => 12,
+                'type' => 'customer',
+            ],
+            $extractedConversation['createdBy']
+        );
+
+        $this->assertEquals(
+            [
                 'type' => 'email',
                 'via' => 'customer',
             ],
-            'cc' => [
-                'bear@normal.com',
-            ],
-            'bcc' => [
-                'bear@secret.com',
-            ],
-            'customer' => [
-                'id' => 152,
-                'email' => 'mycustomer@domain.com',
-            ],
-            'customerWaitingSince' => [
+            $extractedConversation['source']
+        );
+
+        $this->assertEquals(
+            ['bear@normal.com'],
+            $extractedConversation['cc']
+        );
+
+        $this->assertEquals(
+            ['bear@secret.com'],
+            $extractedConversation['bcc']
+        );
+
+        $this->assertEquals(152, $extractedConversation['customer']['id']);
+        $this->assertEquals(
+            'mycustomer@domain.com',
+            $extractedConversation['customer']['email']
+        );
+
+        $this->assertEquals(
+            [
                 'time' => '2012-07-24T20:18:33Z',
                 'friendly' => '20 hours ago',
                 'latestReplyFrom' => 'customer',
             ],
-            'tags' => [
-                'Productive',
-            ],
-            'fields' => [
-                [
-                    'id' => 936,
-                    'name' => 'Account Type',
-                    'value' => 'Administrator',
-                ],
-            ],
-        ], $conversation->extract());
+            $extractedConversation['customerWaitingSince']
+        );
+
+        $this->assertEquals(['Productive'], $extractedConversation['tags']);
+
+        $this->assertEquals(
+            [[
+                'id' => 936,
+                'name' => 'Account Type',
+                'value' => 'Administrator',
+            ]],
+            $extractedConversation['fields']
+        );
     }
 
     public function testExtractsThreads()

--- a/tests/Conversations/Threads/Attachments/AttachmentFactoryTest.php
+++ b/tests/Conversations/Threads/Attachments/AttachmentFactoryTest.php
@@ -17,7 +17,7 @@ class AttachmentFactoryTest extends TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject|Filesystem */
     private $filesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Conversations/Threads/Attachments/AttachmentFactoryTest.php
+++ b/tests/Conversations/Threads/Attachments/AttachmentFactoryTest.php
@@ -7,6 +7,7 @@ namespace HelpScout\Api\Tests\Conversations\Threads\Attachments;
 use HelpScout\Api\Conversations\Threads\Attachments\AttachmentFactory;
 use HelpScout\Api\Exception\RuntimeException;
 use HelpScout\Api\Support\Filesystem;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AttachmentFactoryTest extends TestCase
@@ -14,7 +15,7 @@ class AttachmentFactoryTest extends TestCase
     /** @var AttachmentFactory */
     private $factory;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject|Filesystem */
+    /** @var MockObject */
     private $filesystem;
 
     public function setUp(): void

--- a/tests/Conversations/Threads/Support/HasCustomerTest.php
+++ b/tests/Conversations/Threads/Support/HasCustomerTest.php
@@ -12,7 +12,7 @@ class HasCustomerTest extends TestCase
 {
     use HasCustomer;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Conversations/Threads/Support/HasPartiesToBeNotifiedTest.php
+++ b/tests/Conversations/Threads/Support/HasPartiesToBeNotifiedTest.php
@@ -11,7 +11,7 @@ class HasPartiesToBeNotifiedTest extends TestCase
 {
     use HasPartiesToBeNotified;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Conversations/Threads/Support/HasUserTest.php
+++ b/tests/Conversations/Threads/Support/HasUserTest.php
@@ -12,7 +12,7 @@ class HasUserTest extends TestCase
 {
     use HasUser;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Conversations/Threads/ThreadFactoryTest.php
+++ b/tests/Conversations/Threads/ThreadFactoryTest.php
@@ -18,7 +18,7 @@ class ThreadFactoryTest extends TestCase
     /** @var ThreadFactory */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Entity/PagedCollectionTest.php
+++ b/tests/Entity/PagedCollectionTest.php
@@ -32,7 +32,7 @@ class PagedCollectionTest extends TestCase
      */
     private $collection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->loadedCollection = Mockery::mock(PagedCollection::class);
         $this->pageLoader = new PageLoaderStub($this->loadedCollection);

--- a/tests/Http/AuthenticatorTest.php
+++ b/tests/Http/AuthenticatorTest.php
@@ -16,7 +16,7 @@ class AuthenticatorTest extends TestCase
     /** @var MockInterface|Mockery\LegacyMockInterface */
     public $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = Mockery::mock(Client::class);
     }

--- a/tests/Http/RestClientTest.php
+++ b/tests/Http/RestClientTest.php
@@ -29,7 +29,7 @@ class RestClientTest extends TestCase
     public $methodsClient;
     public $authenticator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->methodsClient = \Mockery::mock(Client::class);
         $this->authenticator = \Mockery::mock(Authenticator::class);

--- a/tests/Tags/TagsCollectionTest.php
+++ b/tests/Tags/TagsCollectionTest.php
@@ -22,6 +22,6 @@ class TagsCollectionTest extends TestCase
 
         $extracted = $tagsCollection->extract();
         $this->assertArrayHasKey('tags', $extracted);
-        $this->assertContains('Support', $extracted['tags'][0]);
+        $this->assertStringContainsStringIgnoringCase('Support', $extracted['tags'][0]);
     }
 }


### PR DESCRIPTION
**⚠️ This should be merged in after #212  to prevent merge conflicts**

This pull request does a couple things: 

1. Requires PHP`7.3` as `7.2` will only be receiving security updates for the majority of 2020. 
2. Upgrades PHPUnit to version 8

The `assertArraySubset()` test method has [been deprecated](https://github.com/sebastianbergmann/phpunit/issues/3494), with no suggested alternative. Luckily there was only a single use that I replaced with `11` explicit assertions.

**Once this is merged, the `phpunit-8` branch/tree can be deleted.**