### PR TITLE
Correct _credentials.php record in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ composer.lock
 coverage
 vendor
 .idea
-./examples/_credentials.php
+examples/_credentials.php
 build
 .DS_Store


### PR DESCRIPTION
This pull request fixes the incorrect `.gitignore` record for the credentials file. 