### PR TITLE
Updating version to reflect this is a beta build

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -23,7 +23,7 @@ use Mockery\LegacyMockInterface;
 
 class ApiClient
 {
-    public const CLIENT_VERSION = '2.5.0';
+    public const CLIENT_VERSION = '3.0.0-master';
 
     public const AVAILABLE_ENDPOINTS = [
         'hs.workflows' => WorkflowsEndpoint::class,


### PR DESCRIPTION
I realized we hadn't updated our version number, so anyone pulling in `master` into their project we would see as using `v2.5`.  This helps us identify them as using the 3.0.0 build based on the `master` branch.