### PR TITLE
Rename UserFilter object methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,8 +816,8 @@ Narrow down the list of Users based on a set of filters.
 use HelpScout\Api\Users\UserFilters;
 
 $filters = (new UserFilters())
-    ->withMailbox(1)
-    ->withEmail('tester@test.com');
+    ->inMailbox(1)
+    ->byEmail('tester@test.com');
 
 $users = $client->users()->list($filters);
 ```

--- a/examples/users.php
+++ b/examples/users.php
@@ -12,7 +12,7 @@ $client->useClientCredentials($appId, $appSecret);
 $users = $client->users()->list();
 
 $filters = (new UserFilters())
-    ->withMailbox(197271);
+    ->inMailbox(197271);
 
 $users = $client->users()->list($filters);
 

--- a/src/Users/UserFilters.php
+++ b/src/Users/UserFilters.php
@@ -9,7 +9,7 @@ use HelpScout\Api\Assert\Assert;
 class UserFilters
 {
     /**
-     * @var integer
+     * @var int
      */
     private $mailbox;
 

--- a/src/Users/UserFilters.php
+++ b/src/Users/UserFilters.php
@@ -9,7 +9,7 @@ use HelpScout\Api\Assert\Assert;
 class UserFilters
 {
     /**
-     * @var int
+     * @var integer
      */
     private $mailbox;
 
@@ -29,10 +29,7 @@ class UserFilters
         return array_filter($params);
     }
 
-    /**
-     * @return self
-     */
-    public function withMailbox(int $mailbox)
+    public function inMailbox(int $mailbox): UserFilters
     {
         Assert::greaterThan($mailbox, 0);
 
@@ -42,10 +39,7 @@ class UserFilters
         return $filters;
     }
 
-    /**
-     * @return self
-     */
-    public function withEmail(string $email)
+    public function byEmail(string $email): UserFilters
     {
         $filters = clone $this;
         $filters->email = $email;

--- a/tests/Users/UserClientIntegrationTest.php
+++ b/tests/Users/UserClientIntegrationTest.php
@@ -117,7 +117,7 @@ class UserClientIntegrationTest extends ApiClientIntegrationTestCase
         );
 
         $filters = (new UserFilters())
-            ->withMailbox(256);
+            ->inMailbox(256);
 
         $users = $this->client->users()->list($filters);
 

--- a/tests/Users/UserFiltersTest.php
+++ b/tests/Users/UserFiltersTest.php
@@ -19,8 +19,8 @@ class UserFiltersTest extends TestCase
     public function testGetParams()
     {
         $filters = (new UserFilters())
-            ->withMailbox(1)
-            ->withEmail('tester@test.com');
+            ->inMailbox(1)
+            ->byEmail('tester@test.com');
 
         $this->assertSame([
             'mailbox' => 1,


### PR DESCRIPTION
Relates to #208

To reduce confusion when using a UserFilter object some methods have been changed. This is a breaking change targeting version 3. All usages and tests have been updated.

Changes

1. withEmail => byEmail
2. withMailbox => inMailbox

~To be merged in after #224~ 