### PR TITLE
Rename CustomerFilter object methods for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ provides a simple interface to set filter values. For example:
 use HelpScout\Api\Customers\CustomerFilters;
 
 $filter = (new CustomerFilters())
-    ->withFirstName('Tom')
-    ->withLastName('Graham');
+    ->byFirstName('Tom')
+    ->byLastName('Graham');
 
 $customers = $client->customers()->list($filter);
 ```

--- a/examples/customers.php
+++ b/examples/customers.php
@@ -32,13 +32,13 @@ foreach($customers as $customer) {
 }
 
 $filters = (new CustomerFilters())
-    ->withFirstName('John')
-    ->withLastName('Smith')
-    ->withMailbox('12')
-    ->withModifiedSince(new DateTime('last month'))
+    ->byFirstName('John')
+    ->byLastName('Smith')
+    ->inMailbox('12')
+    ->modifiedSince(new DateTime('last month'))
     // See https://developer.helpscout.com/mailbox-api/endpoints/customers/list/#query for details on what you can do with query
     ->withQuery('email:"alan@easycrypto.nz"')
-    ->withSortField('createdAt')
-    ->withSortOrder('asc');
+    ->sortField('createdAt')
+    ->sortOrder('asc');
 
 $customers = $client->customers()->list($filters);

--- a/src/Customers/CustomerFilters.php
+++ b/src/Customers/CustomerFilters.php
@@ -64,10 +64,7 @@ class CustomerFilters
         });
     }
 
-    /**
-     * @return self
-     */
-    public function withMailbox(int $mailbox)
+    public function inMailbox(int $mailbox): CustomerFilters
     {
         Assert::greaterThan($mailbox, 0);
 
@@ -77,10 +74,7 @@ class CustomerFilters
         return $filters;
     }
 
-    /**
-     * @return self
-     */
-    public function withFirstName(string $firstName)
+    public function byFirstName(string $firstName): CustomerFilters
     {
         $filters = clone $this;
         $filters->firstName = $firstName;
@@ -88,10 +82,7 @@ class CustomerFilters
         return $filters;
     }
 
-    /**
-     * @return self
-     */
-    public function withLastName(string $lastName)
+    public function byLastName(string $lastName): CustomerFilters
     {
         $filters = clone $this;
         $filters->lastName = $lastName;
@@ -99,10 +90,7 @@ class CustomerFilters
         return $filters;
     }
 
-    /**
-     * @return self
-     */
-    public function withModifiedSince(DateTime $modifiedSince)
+    public function modifiedSince(DateTime $modifiedSince): CustomerFilters
     {
         $modifiedSince->setTimezone(new DateTimeZone('UTC'));
 
@@ -112,10 +100,7 @@ class CustomerFilters
         return $filters;
     }
 
-    /**
-     * @return self
-     */
-    public function withSortField(string $sortField)
+    public function sortField(string $sortField): CustomerFilters
     {
         Assert::oneOf($sortField, ['score', 'firstName', 'lastName', 'modifiedAt']);
 
@@ -125,10 +110,7 @@ class CustomerFilters
         return $filters;
     }
 
-    /**
-     * @return self
-     */
-    public function withSortOrder(string $sortOrder)
+    public function sortOrder(string $sortOrder): CustomerFilters
     {
         $sortOrder = strtolower($sortOrder);
         Assert::oneOf($sortOrder, ['asc', 'desc']);
@@ -141,10 +123,8 @@ class CustomerFilters
 
     /**
      * @see https://developer.helpscout.com/mailbox-api/endpoints/customers/list/#query
-     *
-     * @return self
      */
-    public function withQuery(string $query)
+    public function withQuery(string $query): CustomerFilters
     {
         $filters = clone $this;
         $filters->query = $query;

--- a/tests/Customers/CustomerClientIntegrationTest.php
+++ b/tests/Customers/CustomerClientIntegrationTest.php
@@ -223,8 +223,8 @@ class CustomerClientIntegrationTest extends ApiClientIntegrationTestCase
         );
 
         $filters = (new CustomerFilters())
-            ->withFirstName('Tom')
-            ->withLastName('Graham');
+            ->byFirstName('Tom')
+            ->byLastName('Graham');
 
         $customers = $this->client->customers()->list($filters);
 

--- a/tests/Customers/CustomerFiltersTest.php
+++ b/tests/Customers/CustomerFiltersTest.php
@@ -21,12 +21,12 @@ class CustomerFiltersTest extends TestCase
     public function testGetParams()
     {
         $filters = (new CustomerFilters())
-            ->withMailbox(1)
-            ->withFirstName('Tom')
-            ->withLastName('Graham')
-            ->withModifiedSince(new DateTime('2017-05-06T09:04:23+05:00'))
-            ->withSortField('firstName')
-            ->withSortOrder('asc')
+            ->inMailbox(1)
+            ->byFirstName('Tom')
+            ->byLastName('Graham')
+            ->modifiedSince(new DateTime('2017-05-06T09:04:23+05:00'))
+            ->sortField('firstName')
+            ->sortOrder('asc')
             ->withQuery('query');
 
         $this->assertSame([
@@ -44,8 +44,7 @@ class CustomerFiltersTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $filters = (new CustomerFilters())
-            ->withMailbox(0);
+        (new CustomerFilters())->inMailbox(0);
     }
 
     /**
@@ -54,7 +53,7 @@ class CustomerFiltersTest extends TestCase
     public function testWithValidSortField($sortField)
     {
         $filters = (new CustomerFilters())
-            ->withSortField($sortField);
+            ->sortField($sortField);
 
         $this->assertSame([
             'sortField' => $sortField,
@@ -75,8 +74,7 @@ class CustomerFiltersTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $filters = (new CustomerFilters())
-            ->withSortField('invalid');
+        (new CustomerFilters())->sortField('invalid');
     }
 
     /**
@@ -85,7 +83,7 @@ class CustomerFiltersTest extends TestCase
     public function testWithValidSortOrder($sortOrder, $sortOrderParam)
     {
         $filters = (new CustomerFilters())
-            ->withSortOrder($sortOrder);
+            ->sortOrder($sortOrder);
 
         $this->assertSame([
             'sortOrder' => $sortOrderParam,
@@ -106,7 +104,6 @@ class CustomerFiltersTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $filters = (new CustomerFilters())
-            ->withSortOrder('invalid');
+        (new CustomerFilters())->sortOrder('invalid');
     }
 }


### PR DESCRIPTION
Relates to #208

To reduce confusion when using a CustomerFilter object some methods have been changed. This is a breaking change targeting version 3. All usages and tests have been updated.

Changes

1. withFirstName => byFirstName
2. withLastName => byLastName
3. withMailbox => inMailbox
4. withModifiedSince => modifiedSince
5. withSortField => sortField
6. withSortOrder => sortOrder

~To be merged in after #224~