### PR TITLE
Add isAssigned method to Thread object for convenience

### DIFF
--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -287,6 +287,11 @@ class Thread implements Extractable, Hydratable
         return $this;
     }
 
+    public function isAssigned(): bool
+    {
+        return $this->assignedTo !== null && !empty($this->assignedTo);
+    }
+
     public function getAssignedTo(): ?array
     {
         return $this->assignedTo;

--- a/tests/Conversations/Threads/ThreadTest.php
+++ b/tests/Conversations/Threads/ThreadTest.php
@@ -305,4 +305,33 @@ class ThreadTest extends TestCase
         $this->assertTrue($thread->hasAttachments());
         $this->assertSame($attachment, $thread->getAttachments()->toArray()[0]);
     }
+
+    public function testIsAssignedReturnsFalseByDefault()
+    {
+        $this->assertFalse((new Thread())->isAssigned());
+    }
+
+    public function testIsAssignedReturnsFalseIfEmptyArray()
+    {
+        $thread = new Thread();
+        $thread->hydrate(['assignedTo' => []]);
+
+        $this->assertFalse($thread->isAssigned());
+    }
+
+    public function testIsAssigned()
+    {
+        $thread = new Thread();
+        $thread->hydrate([
+            'assignedTo' => [
+                'id' => 1234,
+                'type' => 'team',
+                'first' => 'Jack',
+                'last' => 'Sprout',
+                'email' => 'bear@acme.com',
+            ],
+        ]);
+
+        $this->assertTrue($thread->isAssigned());
+    }
 }


### PR DESCRIPTION
Closes #75 

This pull request adds a `isAssigned` method to the Thread class to conveniently return a boolean to determine whether a Thread is assigned or not. This prevents developers from doing additional checks against mixed returns. 