### PR TITLE
Adding example for automatically refreshing a token and trying again

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ use HelpScout\Api\ApiClientFactory;
 
 $client = ApiClientFactory::createClient();
 
-// Set Auth token directly if you have it
-$client->setAccessToken('abc123');
-
-// Set Client credentials if using that grant type
+// Set Client credentials if using that grant type.  Using this approach will lazily fetch an access token on-demand
+// when needed.  
 $client->useClientCredentials($appId, $appSecret);
+
+// Set Access token directly if you have it
+$client->setAccessToken('abc123');
 
 // Use a refresh token to get a new access token
 $client->useRefreshToken($appId, $appSecret, $refreshToken);
@@ -94,7 +95,7 @@ $client->getAuthenticator()->fetchAccessAndRefreshToken();
 To persist the updated token you can use the authenticator that is returned:
 
 ```
-$client->getAuthenticator()->fetchAccessAndRefreshToken()->getTokens(); // array
+$client->getAuthenticator()->fetchAccessAndRefreshToken()->accessToken();
 ```
 
 ### Authorization Code Flow

--- a/examples/refresh-token-and-retry.php
+++ b/examples/refresh-token-and-retry.php
@@ -1,0 +1,32 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require '_credentials.php';
+
+use HelpScout\Api\ApiClient;
+use HelpScout\Api\ApiClientFactory;
+
+$client = ApiClientFactory::createClient();
+$client = $client->useClientCredentials($appId, $appSecret);
+
+/**
+ * This example shows how to catch an Auth exception, refresh the token and retry the same work again.
+ */
+function autoRefreshToken(ApiClient $client, Closure $closure) {
+    $attempts = 0;
+    do {
+        try {
+            return $closure($client);
+        } catch (\HelpScout\Api\Exception\AuthenticationException $e) {
+            $client->getAuthenticator()->fetchAccessAndRefreshToken();
+        }
+        $attempts++;
+    } while($attempts < 1);
+
+    throw new RuntimeException('Authentication failure loop encountered');
+}
+
+$users = autoRefreshToken($client, function (ApiClient $client) {
+    return $client->users()->list();
+});
+
+print_r($users->getFirstPage()->toArray());

--- a/examples/refresh-token-and-retry.php
+++ b/examples/refresh-token-and-retry.php
@@ -11,11 +11,11 @@ $client = $client->useClientCredentials($appId, $appSecret);
 /**
  * This example shows how to catch an Auth exception, refresh the token and retry the same work again.
  */
-function autoRefreshToken(ApiClient $client, Closure $closure) {
+function autoRefreshToken(ApiClient $client, Closure $workToRetry) {
     $attempts = 0;
     do {
         try {
-            return $closure($client);
+            return $workToRetry($client);
         } catch (\HelpScout\Api\Exception\AuthenticationException $e) {
             $client->getAuthenticator()->fetchAccessAndRefreshToken();
         }


### PR DESCRIPTION
Ideally, the SDK internally would implement the ability to refresh automatically via a [Guzzle middleware](https://addshore.com/2015/12/guzzle-6-retry-middleware/) that would enable the automatic renewal of a refresh token when expired, then automatically retry the original request.

Since we don't have that, this pull request adds an example of how work can be retried today (originally suggested in https://github.com/helpscout/helpscout-api-php/issues/236#issuecomment-634153449).