### PR TITLE
Example for thread not existing

### DIFF
--- a/examples/threads.php
+++ b/examples/threads.php
@@ -42,5 +42,11 @@ $threadId = 0;
 $client->threads()->updateText(18, $threadId, 'I need help please');
 
 // Get the source of a thread
-$source = $client->threads()->getSource(1189656771, 3394140565);
+try {
+    $source = $client->threads()->getSource(1189656771, 3394140565);
+} catch (\GuzzleHttp\Exception\ClientException $e) {
+    if ($e->getResponse()->getStatusCode() === 404) {
+        // thread's source not available
+    }
+}
 print_r($source->getOriginal());


### PR DESCRIPTION
Adding an example of how to identify when a thread's original source is not available.