### PR TITLE
Add support for Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3",
         "ql/uri-template": "^1.1",
         "webmozart/assert": "^1.2",
-        "guzzlehttp/guzzle": "^7.0.1"
+        "guzzlehttp/guzzle": "^6.3|^7.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3",
         "ql/uri-template": "^1.1",
         "webmozart/assert": "^1.2",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^7.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/src/Http/RestClientBuilder.php
+++ b/src/Http/RestClientBuilder.php
@@ -6,7 +6,7 @@ namespace HelpScout\Api\Http;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
@@ -122,7 +122,7 @@ class RestClientBuilder
             $retries,
             Request $request,
             Response $response = null,
-            RequestException $exception = null
+            GuzzleException $exception = null
         ) {
             // Don't retry unless this is a Connection issue
             if (!$exception instanceof ConnectException) {

--- a/tests/Http/RestClientTest.php
+++ b/tests/Http/RestClientTest.php
@@ -193,10 +193,13 @@ class RestClientTest extends TestCase
             'POST',
             'https://api.helpscout.net/v2/uuid-4/chat'
         );
-
-        $serverException = new ServerException('BAD_REQUEST', $request);
-
         $badResponse = new Response(400, [], 'bad response');
+
+        $serverException = new ServerException(
+            'BAD_REQUEST',
+            $request,
+            $badResponse
+        );
 
         $connectionException = new ConnectException(
             'SERVER_WENT_AWAY',


### PR DESCRIPTION
This PR adjusts expectations of Guzzle exception types to enable use of either v6 or v7.

It was necessary to do this to allow this API to be imported into a Laravel v8 project as that framework now [requires Guzzle v7](https://laravel.com/docs/8.x/upgrade#updating-dependencies). I doubt I will be the last person to encounter that problem.

I did not examine your exception handling logic exhaustively, but I believe adjusting `RestClientBuilder::getRetryDecider` to accept a base `GuzzleException` does not cause any change in behaviour.

All tests are passing locally with Guzzle6 and Guzzle7.

I hope you will give this PR some consideration and please let me know if you need anything else.