### PR TITLE
add 2 sort options to Conversation Filter

### DIFF
--- a/src/Conversations/ConversationFilters.php
+++ b/src/Conversations/ConversationFilters.php
@@ -197,12 +197,14 @@ class ConversationFilters
         Assert::oneOf($sortField, [
             'createdAt',
             'customerEmail',
+            'customerName',
             'mailboxid',
             'modifiedAt',
             'number',
             'score',
             'status',
             'subject',
+            'waitingSince',
         ]);
 
         $filters = clone $this;


### PR DESCRIPTION
HelpScout API allows 2 filter options which aren't recognized in this project.  I'd like to add these filters.

Here's the HelpScout API documentation listing the filter options:
https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/#url-parameters

