### PR TITLE
Gracefully handle hydrating who created a convo

### DIFF
--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -216,7 +216,7 @@ class Conversation implements Extractable, Hydratable
             $this->setAssignee($assignee);
         }
 
-        if (isset($data['createdBy'])) {
+        if (isset($data['createdBy']) && isset($data['createdBy']['id']) && $data['createdBy']['id'] > 0) {
             $this->hydrateCreatedBy($data['createdBy']);
         }
 

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -216,7 +216,7 @@ class Conversation implements Extractable, Hydratable
             $this->setAssignee($assignee);
         }
 
-        if (isset($data['createdBy']) && isset($data['createdBy']['id']) && $data['createdBy']['id'] > 0) {
+        if (($data['createdBy']['id'] ?? 0) > 0) {
             $this->hydrateCreatedBy($data['createdBy']);
         }
 

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -146,6 +146,22 @@ class ConversationTest extends TestCase
         $this->assertSame('33077', $customField->getValue());
     }
 
+
+    public function testHydrateWhenCustomerExistsButIsNull()
+    {
+        $conversation = new Conversation();
+
+        $this->assertFalse($conversation->wasCreatedByCustomer());
+        $this->assertFalse($conversation->wasCreatedByUser());
+
+        $conversation->hydrate([
+            'createdBy' => null,
+        ]);
+
+        $this->assertFalse($conversation->wasCreatedByCustomer());
+        $this->assertFalse($conversation->wasCreatedByUser());
+    }
+
     public function testExtractsCreatedByUser()
     {
         $conversation = new Conversation();

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -155,7 +155,9 @@ class ConversationTest extends TestCase
         $this->assertFalse($conversation->wasCreatedByUser());
 
         $conversation->hydrate([
-            'createdBy' => null,
+            'createdBy' => [
+                'id' => 0,
+            ],
         ]);
 
         $this->assertFalse($conversation->wasCreatedByCustomer());

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -146,7 +146,6 @@ class ConversationTest extends TestCase
         $this->assertSame('33077', $customField->getValue());
     }
 
-
     public function testHydrateWhenCustomerExistsButIsNull()
     {
         $conversation = new Conversation();


### PR DESCRIPTION
In the event a User created a convo and the user is deleted, the API may return an empty createdBy id.  This PR updates the code so the user is only hydrated if a valid id is specified.

Closes https://github.com/helpscout/helpscout-api-php/issues/258

