### PR TITLE
Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ql/uri-template": "^1.1",
         "webmozart/assert": "^1.2",
         "guzzlehttp/guzzle": "^6.3|^7.0.1"

--- a/tests/Webhooks/IncomingWebhookTest.php
+++ b/tests/Webhooks/IncomingWebhookTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class IncomingWebhookTest extends TestCase
 {
-    protected function createRequest(array $headers = [], string $body)
+    protected function createRequest(array $headers, string $body)
     {
         return new Request('POST', 'www.blah.blah', $headers, $body);
     }


### PR DESCRIPTION
Thank you!

```
$  php -v
PHP 8.0.0 (cli) (built: Dec 10 2020 01:42:25) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.0-dev, Copyright (c) Zend Technologies
    with Xdebug v3.0.1, Copyright (c) 2002-2020, by Derick Rethans

$ vendor/bin/phpunit
PHPUnit 8.5.14 by Sebastian Bergmann and contributors.

Error:         This version of PHPUnit does not support code coverage on PHP 8

...............................................................  63 / 516 ( 12%)
............................................................... 126 / 516 ( 24%)
............................................................... 189 / 516 ( 36%)
............................................................... 252 / 516 ( 48%)
............................................................... 315 / 516 ( 61%)
............................................................... 378 / 516 ( 73%)
............................................................... 441 / 516 ( 85%)
............................................................... 504 / 516 ( 97%)
............                                                    516 / 516 (100%)

Time: 641 ms, Memory: 22.00 MB
```