### PR TITLE
Adding more potential Webhook header signature/event variants

### DIFF
--- a/src/Webhooks/IncomingWebhook.php
+++ b/src/Webhooks/IncomingWebhook.php
@@ -17,11 +17,13 @@ class IncomingWebhook
     public const SIGNATURE_HEADERS = [
         'HTTP_X_HELPSCOUT_SIGNATURE',
         'X_HELPSCOUT_SIGNATURE',
+        'x-helpscout-signature',
     ];
 
     public const EVENT_HEADERS = [
         'HTTP_X_HELPSCOUT_EVENT',
         'X_HELPSCOUT_EVENT',
+        'x-helpscout-event',
     ];
 
     public const TEST_EVENT = 'helpscout.test';


### PR DESCRIPTION
https://github.com/helpscout/helpscout-api-php/issues/272 was raised identifying some variants of the headers that aren't recognized with some libraries.  This PR makes the SDK aware of these potential variants so it's able to correctly identify the event and signature of incoming webhooks.