### PR TITLE
Exceptions now thrown when failing to encode entities

### DIFF
--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -156,6 +156,9 @@ class RestClient
         return HalDeserializer::deserializeResources($entityClass, $rel, $halDocument);
     }
 
+    /**
+     * @throws \JsonException
+     */
     private function encodeEntity(Extractable $entity): string
     {
         return json_encode($entity->extract(), JSON_THROW_ON_ERROR);

--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -158,7 +158,7 @@ class RestClient
 
     private function encodeEntity(Extractable $entity): string
     {
-        return json_encode($entity->extract());
+        return json_encode($entity->extract(), JSON_THROW_ON_ERROR);
     }
 
     /**


### PR DESCRIPTION
This PR is a follow up to https://github.com/helpscout/helpscout-api-php/issues/277.  While this doesn't resolve the underlying issue as to why the encoding wasn't successful, it does make the error surface more clearly.  Throwing an exception is not a breaking change here because the return type expects a string, so any `false` return value from `json_encode()` will error out anyways.