### PR TITLE
Repeat the request with new auth headers

### DIFF
--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -182,6 +182,10 @@ class RestClient
             $authenticator = $this->getAuthenticator();
             if ($authenticator->shouldAutoRefreshAccessToken()) {
                 $authenticator->fetchAccessAndRefreshToken();
+                // replace the auth headers in the Request object
+                foreach ($this->getAuthHeader() as $header => $value) {
+                    $request = $request->withHeader($header, $value);
+                }
                 $response = $this->client->send($request, $options);
             } else {
                 throw $e;

--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -182,7 +182,7 @@ class RestClient
             $authenticator = $this->getAuthenticator();
             if ($authenticator->shouldAutoRefreshAccessToken()) {
                 $authenticator->fetchAccessAndRefreshToken();
-                // replace the auth headers in the Request object
+                // Replace the auth headers in the Request object.
                 foreach ($this->getAuthHeader() as $header => $value) {
                     $request = $request->withHeader($header, $value);
                 }

--- a/tests/Http/RestClientTest.php
+++ b/tests/Http/RestClientTest.php
@@ -88,7 +88,7 @@ class RestClientTest extends TestCase
             ->andThrow($exception);
 
         $this->authenticator->shouldReceive([
-            'getAuthHeader' => [],
+            'getAuthHeader' => ['the-header' => 'the-value'],
             'shouldAutoRefreshAccessToken' => false,
         ]);
         $this->authenticator->shouldReceive('fetchAccessAndRefreshToken')
@@ -106,7 +106,7 @@ class RestClientTest extends TestCase
             ->once();
 
         $this->authenticator->shouldReceive([
-            'getAuthHeader' => [],
+            'getAuthHeader' => ['the-header' => 'the-value'],
             'shouldAutoRefreshAccessToken' => true,
         ]);
         $this->authenticator->shouldReceive('fetchAccessAndRefreshToken')
@@ -118,6 +118,11 @@ class RestClientTest extends TestCase
         ];
         $response = new Response(200, [], json_encode($responseData));
         $this->methodsClient->shouldReceive('send')
+            ->with(\Mockery::on(function (Request $request) {
+                // Ensure retry request includes new auth headers.
+                $this->assertSame(['the-value'], $request->getHeader('the-header'));
+                return true;
+            }), \Mockery::any())
             ->andReturn($response);
 
         $restClient = new RestClient($this->methodsClient, $this->authenticator);


### PR DESCRIPTION
"If the request fails due to an authentication error, retry again after refreshing the token"
The "retry" should happen on the old Request object with new auth headers.