### PR TITLE
Conversation CustomField text property missing from API

### DIFF
--- a/src/Conversations/CustomField.php
+++ b/src/Conversations/CustomField.php
@@ -25,6 +25,11 @@ class CustomField implements Extractable, Hydratable
      */
     private $value;
 
+    /**
+     * @var string|null
+     */
+    private $text;
+
     public function hydrate(array $data, array $embedded = [])
     {
         if (isset($data['id'])) {
@@ -33,6 +38,7 @@ class CustomField implements Extractable, Hydratable
 
         $this->setName($data['name'] ?? null);
         $this->setValue($data['value'] ?? null);
+        $this->setText($data['text'] ?? null);
     }
 
     /**
@@ -44,6 +50,7 @@ class CustomField implements Extractable, Hydratable
             'id' => $this->getId(),
             'name' => $this->getName(),
             'value' => $this->getValue(),
+            'text' => $this->getText(),
         ];
 
         if ($this->getValue() instanceof \DateTimeInterface) {
@@ -93,6 +100,20 @@ class CustomField implements Extractable, Hydratable
     public function setValue($value): self
     {
         $this->value = $value;
+
+        return $this;
+    }
+
+    public function getText(): ?string {
+        return $this->text;
+    }
+
+    /**
+     * @param string|null $text
+     */
+    public function setText($text): self
+    {
+        $this->text = $text;
 
         return $this;
     }

--- a/tests/Conversations/ConversationTest.php
+++ b/tests/Conversations/ConversationTest.php
@@ -238,6 +238,7 @@ class ConversationTest extends TestCase
         $this->assertInstanceOf(CustomField::class, $customField->setId(936));
         $this->assertInstanceOf(CustomField::class, $customField->setName('Account Type'));
         $customField->setValue('Administrator');
+        $customField->setText('Administrator');
         $conversation->setCustomFields(new Collection([
             $customField,
         ]));
@@ -349,6 +350,7 @@ class ConversationTest extends TestCase
                 'id' => 936,
                 'name' => 'Account Type',
                 'value' => 'Administrator',
+                'text' => 'Administrator',
             ]],
             $extractedConversation['fields']
         );

--- a/tests/Conversations/CustomFieldTest.php
+++ b/tests/Conversations/CustomFieldTest.php
@@ -16,11 +16,13 @@ class CustomFieldTest extends TestCase
             'id' => 6688,
             'name' => 'Account Type',
             'value' => 'Premium',
+            'text' => 'Premium',
         ]);
 
         $this->assertSame(6688, $customField->getId());
         $this->assertSame('Account Type', $customField->getName());
         $this->assertSame('Premium', $customField->getValue());
+        $this->assertSame('Premium', $customField->getText());
     }
 
     public function testExtract()
@@ -29,11 +31,13 @@ class CustomFieldTest extends TestCase
         $this->assertInstanceOf(CustomField::class, $customField->setId(6688));
         $this->assertInstanceOf(CustomField::class, $customField->setName('Account Type'));
         $this->assertInstanceOf(CustomField::class, $customField->setValue('Premium'));
+        $this->assertInstanceOf(CustomField::class, $customField->setText('Premium'));
 
         $this->assertSame([
             'id' => 6688,
             'name' => 'Account Type',
             'value' => 'Premium',
+            'text' => 'Premium',
         ], $customField->extract());
     }
 
@@ -48,6 +52,7 @@ class CustomFieldTest extends TestCase
             'id' => 6688,
             'name' => 'Account Type',
             'value' => '2017-01-02',
+            'text' => null,
         ], $customField->extract());
     }
 
@@ -59,6 +64,7 @@ class CustomFieldTest extends TestCase
             'id' => null,
             'name' => null,
             'value' => null,
+            'text' => null,
         ], $customField->extract());
     }
 }

--- a/tests/Conversations/CustomFieldsCollectionTest.php
+++ b/tests/Conversations/CustomFieldsCollectionTest.php
@@ -18,6 +18,7 @@ class CustomFieldsCollectionTest extends TestCase
         $customField->setId(936);
         $customField->setName('Account Type');
         $customField->setValue('Administrator');
+        $customField->setText('Administrator');
 
         $customFieldsCollection->setCustomFields([
             $customField,
@@ -29,6 +30,7 @@ class CustomFieldsCollectionTest extends TestCase
                     'id' => 936,
                     'name' => 'Account Type',
                     'value' => 'Administrator',
+                    'text' => 'Administrator',
                 ],
             ],
         ], $customFieldsCollection->extract());


### PR DESCRIPTION
https://developer.helpscout.com/mailbox-api/endpoints/conversations/get/#custom-fields