### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.php_cs.cache
+.php-cs-fixer.cache
 phpunit.xml
 composer.lock
 coverage

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests');
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setFinder($finder)
     ->setRules([
         '@Symfony' => true,

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",
-        "phpstan/phpstan": "^0.10.1",
-        "friendsofphp/php-cs-fixer": "^2.3",
+        "phpstan/phpstan": "^1.10",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "mockery/mockery": "^1.1",
         "ramsey/uuid": "^4.1"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    ignoreErrors:
-        # Ignore type errors for passing a Mock
-        - '#.*MockObject given.*#'
-        - '#.*MockInterface given.*#'
+    level: 4
+    paths:
+        - src
+        - tests

--- a/src/Conversations/ConversationLinks.php
+++ b/src/Conversations/ConversationLinks.php
@@ -6,12 +6,12 @@ namespace HelpScout\Api\Conversations;
 
 class ConversationLinks
 {
-    const MAILBOX = 'mailbox';
-    const PRIMARY_CUSTOMER = 'primaryCustomer';
-    const CREATED_BY_CUSTOMER = 'createdByCustomer';
-    const CREATED_BY_USER = 'createdByUser';
-    const CLOSED_BY = 'closedBy';
-    const THREADS = 'threads';
-    const ASSIGNEE = 'assignee';
-    const WEB = 'web';
+    public const MAILBOX = 'mailbox';
+    public const PRIMARY_CUSTOMER = 'primaryCustomer';
+    public const CREATED_BY_CUSTOMER = 'createdByCustomer';
+    public const CREATED_BY_USER = 'createdByUser';
+    public const CLOSED_BY = 'closedBy';
+    public const THREADS = 'threads';
+    public const ASSIGNEE = 'assignee';
+    public const WEB = 'web';
 }

--- a/src/Conversations/CustomField.php
+++ b/src/Conversations/CustomField.php
@@ -104,7 +104,8 @@ class CustomField implements Extractable, Hydratable
         return $this;
     }
 
-    public function getText(): ?string {
+    public function getText(): ?string
+    {
         return $this->text;
     }
 

--- a/src/Conversations/Status.php
+++ b/src/Conversations/Status.php
@@ -9,10 +9,10 @@ class Status
     /**
      * We're using the verbiage "ANY" instead of "ALL" because a conversation can only have a single status, not multiple.
      */
-    const ANY = 'all';
-    const ACTIVE = 'active';
-    const CLOSED = 'closed';
-    const OPEN = 'open';
-    const PENDING = 'pending';
-    const SPAM = 'spam';
+    public const ANY = 'all';
+    public const ACTIVE = 'active';
+    public const CLOSED = 'closed';
+    public const OPEN = 'open';
+    public const PENDING = 'pending';
+    public const SPAM = 'spam';
 }

--- a/src/Customers/CustomerLinks.php
+++ b/src/Customers/CustomerLinks.php
@@ -6,10 +6,10 @@ namespace HelpScout\Api\Customers;
 
 class CustomerLinks
 {
-    const ADDRESS = 'address';
-    const CHATS = 'chats';
-    const EMAILS = 'emails';
-    const PHONES = 'phones';
-    const SOCIAL_PROFILES = 'social-profiles';
-    const WEBSITES = 'websites';
+    public const ADDRESS = 'address';
+    public const CHATS = 'chats';
+    public const EMAILS = 'emails';
+    public const PHONES = 'phones';
+    public const SOCIAL_PROFILES = 'social-profiles';
+    public const WEBSITES = 'websites';
 }

--- a/src/Customers/Entry/CustomerEntryEndpoint.php
+++ b/src/Customers/Entry/CustomerEntryEndpoint.php
@@ -20,7 +20,7 @@ class CustomerEntryEndpoint extends Endpoint
     public const CUSTOMER_SOCIAL = '/v2/customers/%d/social-profiles/%d';
     public const CREATE_CUSTOMER_WEBSITE = '/v2/customers/%d/websites';
     public const CUSTOMER_WEBSITE = '/v2/customers/%d/websites/%d';
-    public const CUSTOMER_PROPERTIES= '/v2/customers/%d/properties';
+    public const CUSTOMER_PROPERTIES = '/v2/customers/%d/properties';
 
     public function createAddress(int $customerId, Address $address): ?int
     {

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -44,10 +44,10 @@ abstract class Endpoint
     ): PagedCollection {
         /** @var HalPagedResources $pagedResources */
         $pagedResources = $this->restClient->getResources(
-                $entityClass,
-                $rel,
-                $uri
-            );
+            $entityClass,
+            $rel,
+            $uri
+        );
 
         $mapClosure = function (HalResource $resource) {
             return $resource->getEntity();

--- a/src/Entity/PagedCollection.php
+++ b/src/Entity/PagedCollection.php
@@ -13,12 +13,12 @@ class PagedCollection extends Collection
     /**
      * The link name for the templated page URI.
      */
-    const REL_PAGE = 'page';
+    public const REL_PAGE = 'page';
 
     /**
      * The variable name for the page number in the templated URI.
      */
-    const PAGE_VARIABLE = 'page';
+    public const PAGE_VARIABLE = 'page';
 
     /**
      * @var HalPageMetadata

--- a/src/Http/Hal/HalDeserializer.php
+++ b/src/Http/Hal/HalDeserializer.php
@@ -9,8 +9,8 @@ use HelpScout\Api\Exception\JsonException;
 
 class HalDeserializer
 {
-    const LINKS = '_links';
-    const EMBEDDED = '_embedded';
+    public const LINKS = '_links';
+    public const EMBEDDED = '_embedded';
 
     public static function deserializeDocument(string $json): HalDocument
     {

--- a/src/Http/Hal/HalLink.php
+++ b/src/Http/Hal/HalLink.php
@@ -12,27 +12,27 @@ class HalLink
     /**
      * The first page.
      */
-    const REL_FIRST = 'first';
+    public const REL_FIRST = 'first';
 
     /**
      * The last page.
      */
-    const REL_LAST = 'last';
+    public const REL_LAST = 'last';
 
     /**
      * The next page.
      */
-    const REL_NEXT = 'next';
+    public const REL_NEXT = 'next';
 
     /**
      * The previous page.
      */
-    const REL_PREVIOUS = 'previous';
+    public const REL_PREVIOUS = 'previous';
 
     /**
      * The self relation.
      */
-    const REL_SELF = 'self';
+    public const REL_SELF = 'self';
 
     /**
      * @var string
@@ -77,6 +77,6 @@ class HalLink
             throw new RuntimeException(sprintf('The link "%s" is not templated', $this->getRel()));
         }
 
-        return (new UriTemplate)->expand($this->getHref(), $params);
+        return (new UriTemplate())->expand($this->getHref(), $params);
     }
 }

--- a/src/Http/RestClient.php
+++ b/src/Http/RestClient.php
@@ -14,6 +14,7 @@ use HelpScout\Api\Http\Hal\HalDeserializer;
 use HelpScout\Api\Http\Hal\HalResource;
 use HelpScout\Api\Http\Hal\HalResources;
 use HelpScout\Api\Reports\Report;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class RestClient
@@ -167,7 +168,7 @@ class RestClient
     /**
      * @return mixed|ResponseInterface
      */
-    private function send(Request $request)
+    private function send(RequestInterface $request)
     {
         $options = [
             'base_uri' => self::BASE_URI,

--- a/src/Http/RestClientBuilder.php
+++ b/src/Http/RestClientBuilder.php
@@ -46,6 +46,9 @@ class RestClientBuilder
         );
     }
 
+    /**
+     * @internal
+     */
     protected function getGuzzleClient(): Client
     {
         $options = $this->getOptions();

--- a/src/Mailboxes/MailboxLinks.php
+++ b/src/Mailboxes/MailboxLinks.php
@@ -6,6 +6,6 @@ namespace HelpScout\Api\Mailboxes;
 
 class MailboxLinks
 {
-    const FIELDS = 'fields';
-    const FOLDERS = 'folders';
+    public const FIELDS = 'fields';
+    public const FOLDERS = 'folders';
 }

--- a/tests/Authentication/AuthenticationIntegrationTest.php
+++ b/tests/Authentication/AuthenticationIntegrationTest.php
@@ -119,9 +119,8 @@ class AuthenticationIntegrationTest extends ApiClientIntegrationTestCase
             'Authorization' => 'Bearer fdsafdas',
         ];
 
-        $authenticator = new Authenticator(new Client(), $auth);
+        $authenticator = new Authenticator($this->guzzle, $auth);
 
-        $authenticator->setClient($this->guzzle);
         $result = $authenticator->getAuthHeader();
         $this->assertSame($expectedResult, $result);
     }
@@ -162,10 +161,8 @@ class AuthenticationIntegrationTest extends ApiClientIntegrationTestCase
             'Authorization' => 'Bearer fdsafdas',
         ];
 
-        $authenticator = new Authenticator(new Client(), $auth);
+        $authenticator = new Authenticator($this->guzzle, $auth);
 
-        /* @var Client $client */
-        $authenticator->setClient($this->guzzle);
         $result = $authenticator->getAuthHeader();
         $this->assertSame($expectedResult, $result);
 

--- a/tests/Conversations/Threads/Support/HasCustomerTest.php
+++ b/tests/Conversations/Threads/Support/HasCustomerTest.php
@@ -6,7 +6,7 @@ namespace HelpScout\Api\Tests\Conversations\Threads\Support;
 
 use HelpScout\Api\Customers\Customer;
 use HelpScout\Api\Support\HasCustomer;
-use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class HasCustomerTest extends TestCase
 {

--- a/tests/Conversations/Threads/Support/HasPartiesToBeNotifiedTest.php
+++ b/tests/Conversations/Threads/Support/HasPartiesToBeNotifiedTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Conversations\Threads\Support;
 
 use HelpScout\Api\Conversations\Threads\Support\HasPartiesToBeNotified;
-use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class HasPartiesToBeNotifiedTest extends TestCase
 {

--- a/tests/Conversations/Threads/Support/HasUserTest.php
+++ b/tests/Conversations/Threads/Support/HasUserTest.php
@@ -6,7 +6,7 @@ namespace HelpScout\Api\Tests\Conversations\Threads\Support;
 
 use HelpScout\Api\Conversations\Threads\Support\HasUser;
 use HelpScout\Api\Users\User;
-use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class HasUserTest extends TestCase
 {

--- a/tests/Http/Hal/Entity/StubPayloads.php
+++ b/tests/Http/Hal/Entity/StubPayloads.php
@@ -91,11 +91,6 @@ class StubPayloads
             ],
         ];
 
-        if (empty($entities)) {
-            // The _embedded key is not set when empty
-            unset($data['_embedded']);
-        }
-
         return json_encode($data);
     }
 

--- a/tests/Http/RestClientTest.php
+++ b/tests/Http/RestClientTest.php
@@ -121,6 +121,7 @@ class RestClientTest extends TestCase
             ->with(\Mockery::on(function (Request $request) {
                 // Ensure retry request includes new auth headers.
                 $this->assertSame(['the-value'], $request->getHeader('the-header'));
+
                 return true;
             }), \Mockery::any())
             ->andReturn($response);


### PR DESCRIPTION
I was wondering if I could replace the dependency on Guzzle by a dependency on PSR-18, but it looks like too much work for me.

Still, here are some cleanups I found while having a look:
- update phpstan
- update and run php-cs-fixer
- remove `GuzzleHttp\Client` from the signature of methods, to make it easier to move away from it in the future if needed

It'd be great to decouple the SDK from Guzzle! :pray: 