### PR TITLE
Add ClientException to wrap Guzzle's RequestException

### DIFF
--- a/examples/threads.php
+++ b/examples/threads.php
@@ -44,7 +44,7 @@ $client->threads()->updateText(18, $threadId, 'I need help please');
 // Get the source of a thread
 try {
     $source = $client->threads()->getSource(1189656771, 3394140565);
-} catch (\GuzzleHttp\Exception\ClientException $e) {
+} catch (\HelpScout\Api\Exception\ClientException $e) {
     if ($e->getResponse()->getStatusCode() === 404) {
         // thread's source not available
     }

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use GuzzleHttp\Exception\RequestException;
-
-class AuthenticationException extends RequestException implements Exception
+class AuthenticationException extends ClientException implements Exception
 {
 }

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Exception;
+
+use GuzzleHttp\BodySummarizerInterface;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ClientException extends RequestException implements Exception
+{
+    /**
+     * @internal
+     */
+    public static function create(RequestInterface $request, ResponseInterface $response = null, \Throwable $previous = null, array $handlerContext = [], BodySummarizerInterface $bodySummarizer = null): self
+    {
+        $e = parent::create($request, $response);
+
+        return new self($e->getMessage(), $request, $response, $previous, $handlerContext);
+    }
+}

--- a/src/Exception/RateLimitExceededException.php
+++ b/src/Exception/RateLimitExceededException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use GuzzleHttp\Exception\RequestException;
-
-class RateLimitExceededException extends RequestException implements Exception
+class RateLimitExceededException extends ClientException implements Exception
 {
 }

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use GuzzleHttp\Exception\RequestException;
 use HelpScout\Api\Http\Hal\VndError;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class ValidationErrorException extends RequestException implements Exception
+class ValidationErrorException extends ClientException implements Exception
 {
     /**
      * @var VndError

--- a/src/Http/Handlers/ClientErrorHandler.php
+++ b/src/Http/Handlers/ClientErrorHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Http\Handlers;
 
-use GuzzleHttp\Exception\RequestException;
+use HelpScout\Api\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -16,7 +16,7 @@ class ClientErrorHandler
             return $handler($request, $options)->then(
                 function (ResponseInterface $response) use ($request) {
                     if ($response->getStatusCode() >= 400 && $response->getStatusCode() !== 401) {
-                        $e = RequestException::create($request, $response);
+                        $e = ClientException::create($request, $response);
 
                         throw $e;
                     }

--- a/tests/Error/ValidationErrorIntegrationTest.php
+++ b/tests/Error/ValidationErrorIntegrationTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Error;
 
-use GuzzleHttp\Exception\RequestException;
 use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Exception\ClientException;
 use HelpScout\Api\Exception\ValidationErrorException;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 use HelpScout\Api\Tests\Payloads\ErrorPayloads;
@@ -38,7 +38,7 @@ class ValidationErrorIntegrationTest extends ApiClientIntegrationTestCase
 
     public function testDoesNotHandleValidationErrorWithoutVndErrorContentType()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse(
             $this->getResponse(
@@ -53,7 +53,7 @@ class ValidationErrorIntegrationTest extends ApiClientIntegrationTestCase
 
     public function testDoesNotHandleValidationErrorWithoutContentTypeHeader()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse(
             $this->getResponse(

--- a/tests/Http/Handlers/ClientHandlerTest.php
+++ b/tests/Http/Handlers/ClientHandlerTest.php
@@ -5,45 +5,45 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Http\Handlers;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use HelpScout\Api\ApiClient;
 use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Exception\ClientException;
 use HelpScout\Api\Http\Authenticator;
 use HelpScout\Api\Http\RestClient;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 
 class ClientHandlerTest extends ApiClientIntegrationTestCase
 {
-    public function testRequestExceptionThrownWhenBadRequest()
+    public function testClientExceptionThrownWhenBadRequest()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse($this->getResponse(400, json_encode([])));
 
         $this->client->customers()->get(1);
     }
 
-    public function testRequestExceptionThrownWhenAccessDenied()
+    public function testClientExceptionThrownWhenAccessDenied()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse($this->getResponse(403, json_encode([])));
 
         $this->client->customers()->get(1);
     }
 
-    public function testRequestExceptionThrownWhenNotFound()
+    public function testClientExceptionThrownWhenNotFound()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse($this->getResponse(404, json_encode([])));
 
         $this->client->customers()->get(1);
     }
 
-    public function testRequestExceptionNotThrownWhenNotAuthorized()
+    public function testClientExceptionNotThrownWhenNotAuthorized()
     {
         $this->mockHandler = new MockHandler();
         $handler = HandlerStack::create($this->mockHandler);


### PR DESCRIPTION
To not force userland to couple to symbols in the Guzzle namespace (see updated example)