### PR TITLE
Leverage Psr18Client when possible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,22 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
+        "php-http/discovery": "^1.17",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
         "webmozart/assert": "^1.2",
-        "guzzlehttp/guzzle": "^6.3|^7.0.1",
         "rize/uri-template": "0.3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.4",
+        "guzzlehttp/guzzle": "^7.0.1",
         "mockery/mockery": "^1.1",
         "ramsey/uuid": "^4.1"
+    },
+    "conflict": {
+        "guzzlehttp/guzzle": "<7.0.1"
     },
     "autoload": {
         "psr-4": { "HelpScout\\Api\\": "src/" }
@@ -45,5 +51,10 @@
         "test:report": "vendor/bin/phpunit --coverage-html build/reports/phpunit"
     },
     "minimum-stability": "stable",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
+    }
 }

--- a/examples/threads.php
+++ b/examples/threads.php
@@ -44,7 +44,7 @@ $client->threads()->updateText(18, $threadId, 'I need help please');
 // Get the source of a thread
 try {
     $source = $client->threads()->getSource(1189656771, 3394140565);
-} catch (\GuzzleHttp\Exception\ClientException $e) {
+} catch (\HelpScout\Api\Exception\ClientException $e) {
     if ($e->getResponse()->getStatusCode() === 404) {
         // thread's source not available
     }

--- a/src/ApiClientFactory.php
+++ b/src/ApiClientFactory.php
@@ -7,6 +7,7 @@ namespace HelpScout\Api;
 use Closure;
 use HelpScout\Api\Http\Auth\HandlesTokenRefreshes;
 use HelpScout\Api\Http\RestClientBuilder;
+use Psr\Http\Client\ClientInterface;
 
 class ApiClientFactory
 {
@@ -15,9 +16,10 @@ class ApiClientFactory
      */
     public static function createClient(
         array $config = [],
-        $tokenRefreshedCallback = null
+        $tokenRefreshedCallback = null,
+        ClientInterface $client = null
     ): ApiClient {
-        $restClientBuilder = new RestClientBuilder($config);
+        $restClientBuilder = new RestClientBuilder($config, $client);
 
         return new ApiClient($restClientBuilder->build($tokenRefreshedCallback));
     }

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use GuzzleHttp\Exception\RequestException;
-
-class AuthenticationException extends RequestException implements Exception
+class AuthenticationException extends ClientException implements Exception
 {
 }

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelpScout\Api\Exception;
+
+use GuzzleHttp\BodySummarizerInterface;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ClientException extends RequestException implements Exception
+{
+    /**
+     * @internal
+     */
+    public static function create(RequestInterface $request, ResponseInterface $response = null, \Throwable $previous = null, array $handlerContext = [], BodySummarizerInterface $bodySummarizer = null): self
+    {
+        $e = parent::create($request, $response);
+
+        return new self($e->getMessage(), $request, $response, $previous, $handlerContext);
+    }
+}

--- a/src/Exception/RateLimitExceededException.php
+++ b/src/Exception/RateLimitExceededException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use GuzzleHttp\Exception\RequestException;
-
-class RateLimitExceededException extends RequestException implements Exception
+class RateLimitExceededException extends ClientException implements Exception
 {
 }

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Exception;
 
-use GuzzleHttp\Exception\RequestException;
 use HelpScout\Api\Http\Hal\VndError;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class ValidationErrorException extends RequestException implements Exception
+class ValidationErrorException extends ClientException implements Exception
 {
     /**
      * @var VndError

--- a/src/Http/Handlers/AuthenticationHandler.php
+++ b/src/Http/Handlers/AuthenticationHandler.php
@@ -8,6 +8,9 @@ use HelpScout\Api\Exception\AuthenticationException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @deprecated
+ */
 class AuthenticationHandler
 {
     public function __invoke(callable $handler)

--- a/src/Http/Handlers/ClientErrorHandler.php
+++ b/src/Http/Handlers/ClientErrorHandler.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Http\Handlers;
 
-use GuzzleHttp\Exception\RequestException;
+use HelpScout\Api\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @deprecated
+ */
 class ClientErrorHandler
 {
     public function __invoke(callable $handler)
@@ -16,7 +19,7 @@ class ClientErrorHandler
             return $handler($request, $options)->then(
                 function (ResponseInterface $response) use ($request) {
                     if ($response->getStatusCode() >= 400 && $response->getStatusCode() !== 401) {
-                        $e = RequestException::create($request, $response);
+                        $e = ClientException::create($request, $response);
 
                         throw $e;
                     }

--- a/src/Http/Handlers/RateLimitHandler.php
+++ b/src/Http/Handlers/RateLimitHandler.php
@@ -8,6 +8,9 @@ use HelpScout\Api\Exception\RateLimitExceededException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @deprecated
+ */
 class RateLimitHandler
 {
     public function __invoke(callable $handler)

--- a/src/Http/Handlers/ValidationHandler.php
+++ b/src/Http/Handlers/ValidationHandler.php
@@ -9,6 +9,9 @@ use HelpScout\Api\Http\Hal\HalDeserializer;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @deprecated
+ */
 class ValidationHandler
 {
     public function __invoke(callable $handler)

--- a/tests/ApiClientIntegrationTestCase.php
+++ b/tests/ApiClientIntegrationTestCase.php
@@ -41,6 +41,11 @@ abstract class ApiClientIntegrationTestCase extends TestCase
      */
     protected $client;
 
+    /**
+     * @var string
+     */
+    protected $accessToken = 'abc123';
+
     public function setUp(): void
     {
         $this->history = [];
@@ -57,7 +62,9 @@ abstract class ApiClientIntegrationTestCase extends TestCase
         $client = new Client(['handler' => $handler, 'http_errors' => false]);
 
         $this->authenticator = new Authenticator($client);
-        $this->authenticator->setAccessToken('abc123');
+        if (null !== $this->accessToken) {
+            $this->authenticator->setAccessToken($this->accessToken);
+        }
 
         $this->client = new ApiClient(
             new RestClient($client, $this->authenticator)

--- a/tests/Error/ValidationErrorIntegrationTest.php
+++ b/tests/Error/ValidationErrorIntegrationTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Error;
 
-use GuzzleHttp\Exception\RequestException;
 use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Exception\ClientException;
 use HelpScout\Api\Exception\ValidationErrorException;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 use HelpScout\Api\Tests\Payloads\ErrorPayloads;
@@ -38,7 +38,7 @@ class ValidationErrorIntegrationTest extends ApiClientIntegrationTestCase
 
     public function testDoesNotHandleValidationErrorWithoutVndErrorContentType()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse(
             $this->getResponse(
@@ -53,7 +53,7 @@ class ValidationErrorIntegrationTest extends ApiClientIntegrationTestCase
 
     public function testDoesNotHandleValidationErrorWithoutContentTypeHeader()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse(
             $this->getResponse(

--- a/tests/Http/AuthenticatorTest.php
+++ b/tests/Http/AuthenticatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HelpScout\Api\Tests\Http;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Utils;
 use HelpScout\Api\Http\Auth\Auth;
 use HelpScout\Api\Http\Auth\ClientCredentials;
 use HelpScout\Api\Http\Auth\CodeCredentials;
@@ -60,13 +61,13 @@ class AuthenticatorTest extends TestCase
         $expiresIn = rand(100, 200);
         $refreshToken = uniqid();
         $response = Mockery::mock(ResponseInterface::class, [
-            'getBody' => json_encode([
+            'getBody' => Utils::streamFor(json_encode([
                 'access_token' => $accessToken,
                 'expires_in' => $expiresIn,
                 'refresh_token' => $refreshToken,
-            ]),
+            ])),
         ]);
-        $this->client->shouldReceive('request')
+        $this->client->shouldReceive('sendRequest')
             ->andReturn($response);
 
         $authenticator = new Authenticator($this->client, $authType);
@@ -88,13 +89,13 @@ class AuthenticatorTest extends TestCase
         $expiresIn = rand(100, 200);
         $refreshToken = uniqid();
         $response = Mockery::mock(ResponseInterface::class, [
-            'getBody' => json_encode([
+            'getBody' => Utils::streamFor(json_encode([
                 'access_token' => $accessToken,
                 'expires_in' => $expiresIn,
                 'refresh_token' => $refreshToken,
-            ]),
+            ])),
         ]);
-        $this->client->shouldReceive('request')
+        $this->client->shouldReceive('sendRequest')
             ->andReturn($response);
 
         $callbackExecuted = false;
@@ -122,13 +123,13 @@ class AuthenticatorTest extends TestCase
         $expiresIn = rand(100, 200);
         $refreshToken = uniqid();
         $response = Mockery::mock(ResponseInterface::class, [
-            'getBody' => json_encode([
+            'getBody' => Utils::streamFor(json_encode([
                 'access_token' => $accessToken,
                 'expires_in' => $expiresIn,
                 'refresh_token' => $refreshToken,
-            ]),
+            ])),
         ]);
-        $this->client->shouldReceive('request')
+        $this->client->shouldReceive('sendRequest')
             ->andReturn($response);
 
         $callback = new class() implements HandlesTokenRefreshes {

--- a/tests/Http/Handlers/ClientHandlerTest.php
+++ b/tests/Http/Handlers/ClientHandlerTest.php
@@ -4,63 +4,45 @@ declare(strict_types=1);
 
 namespace HelpScout\Api\Tests\Http\Handlers;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use HelpScout\Api\ApiClient;
-use HelpScout\Api\Customers\Customer;
-use HelpScout\Api\Http\Authenticator;
-use HelpScout\Api\Http\RestClient;
+use HelpScout\Api\Exception\AuthenticationException;
+use HelpScout\Api\Exception\ClientException;
 use HelpScout\Api\Tests\ApiClientIntegrationTestCase;
 
 class ClientHandlerTest extends ApiClientIntegrationTestCase
 {
-    public function testRequestExceptionThrownWhenBadRequest()
+    public function testClientExceptionThrownWhenBadRequest()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse($this->getResponse(400, json_encode([])));
 
         $this->client->customers()->get(1);
     }
 
-    public function testRequestExceptionThrownWhenAccessDenied()
+    public function testClientExceptionThrownWhenAccessDenied()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse($this->getResponse(403, json_encode([])));
 
         $this->client->customers()->get(1);
     }
 
-    public function testRequestExceptionThrownWhenNotFound()
+    public function testClientExceptionThrownWhenNotFound()
     {
-        $this->expectException(RequestException::class);
+        $this->expectException(ClientException::class);
 
         $this->stubResponse($this->getResponse(404, json_encode([])));
 
         $this->client->customers()->get(1);
     }
 
-    public function testRequestExceptionNotThrownWhenNotAuthorized()
+    public function testClientExceptionNotThrownWhenNotAuthorized()
     {
-        $this->mockHandler = new MockHandler();
-        $handler = HandlerStack::create($this->mockHandler);
-
-        $client = new Client(['handler' => $handler]);
-        $this->authenticator = new Authenticator($client);
-        $this->authenticator->setAccessToken('abc123');
-
-        $this->client = new ApiClient(
-            new RestClient($client, $this->authenticator)
-        );
+        $this->expectException(AuthenticationException::class);
 
         $this->stubResponse($this->getResponse(401, json_encode([])));
 
-        $this->assertInstanceOf(
-            Customer::class,
-            $this->client->customers()->get(1)
-        );
+        $this->client->customers()->get(1);
     }
 }


### PR DESCRIPTION
Since #309 was received with praise, I decided to spend a few hours on the topic, so here we are: this PR allows switching to a PSR-18 client.

It does so without breaking compatibility with existing deployment, since using PSR-18 is opt-in.

1st commit is #309
2nd commit is #310

The implementation leverages Psr18Client from [php-http/discovery](https://packagist.org/packages/php-http/discovery) to provide a smooth experience.

The user-facing side of this PR is `ApiClientFactory::createClient()`, which gets a 2nd argument to allow injecting a PSR-18 implementation. This enables nicely integrating the SDK with e.g. the Symfony profiler toolbar.

When Guzzle isn't installed but Symfony is (and no client is explicitly passed to `ApiClientFactory::createClient()`), `RestClientBuilder` will instantiate a retryable HttpClient from Symfony. 