### PR TITLE
feat(conversations): Added "missing" functionality to get truncated threads

### DIFF
--- a/src/Conversations/ConversationFilters.php
+++ b/src/Conversations/ConversationFilters.php
@@ -66,6 +66,11 @@ class ConversationFilters
      */
     private $query;
 
+    /**
+     * @var string
+     */
+    public $embed;
+
     public function getParams(): array
     {
         $params = [
@@ -78,6 +83,7 @@ class ConversationFilters
             'sortField' => $this->sortField,
             'sortOrder' => $this->sortOrder,
             'query' => $this->query,
+            'embed' => $this->embed,
         ];
 
         if (\is_array($this->tag)) {
@@ -240,4 +246,15 @@ class ConversationFilters
         return $filters;
     }
 
+    public function withEmbed(string $embed): ConversationFilters
+    {
+        Assert::oneOf($embed, [
+            'threads',
+        ]);
+
+        $filters = clone $this;
+        $filters->embed = $embed;
+
+        return $filters;
+    }
 }

--- a/tests/Conversations/ConversationFiltersTest.php
+++ b/tests/Conversations/ConversationFiltersTest.php
@@ -32,7 +32,8 @@ class ConversationFiltersTest extends TestCase
             ->sortField('createdAt')
             ->sortOrder('asc')
             ->withQuery('query')
-            ->byCustomField(123, 'blue');
+            ->byCustomField(123, 'blue')
+            ->withEmbed('threads');
 
         $this->assertSame([
             'mailbox' => 1,
@@ -44,6 +45,7 @@ class ConversationFiltersTest extends TestCase
             'sortField' => 'createdAt',
             'sortOrder' => 'asc',
             'query' => 'query',
+            'embed' => 'threads',
             'tag' => 'testing',
             'customFieldsByIds' => '123:blue',
         ], $filters->getParams());

--- a/tests/Conversations/ConversationIntegrationTest.php
+++ b/tests/Conversations/ConversationIntegrationTest.php
@@ -230,6 +230,24 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
         ]);
     }
 
+    public function testGetConversationWithEmbedThreads()
+    {
+        $this->stubResponse($this->getResponse(200, ConversationPayloads::getConversations(1, 10)));
+
+        $filters = (new ConversationFilters())
+            ->withEmbed('threads');
+
+        $conversations = $this->client->conversations()->list($filters);
+
+        $this->assertCount(10, $conversations);
+        $this->assertInstanceOf(Conversation::class, $conversations[0]);
+        $this->assertInstanceOf(CustomerThread::class, $conversations[0]['_embedded']['threads'][0]);
+
+        $this->verifyMultipleRequests([
+            ['GET', 'https://api.helpscout.net/v2/conversations/1'],
+        ]);
+    }
+
     public function testListConversations()
     {
         $this->stubResponse(

--- a/tests/Conversations/ConversationIntegrationTest.php
+++ b/tests/Conversations/ConversationIntegrationTest.php
@@ -232,7 +232,7 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
 
     public function testGetConversationWithEmbedThreads()
     {
-        $this->stubResponse($this->getResponse(200, ConversationPayloads::getConversations(1, 10)));
+        $this->stubResponse($this->getResponse(200, ConversationPayloads::getConversations(1, 10, true)));
 
         $filters = (new ConversationFilters())
             ->withEmbed('threads');
@@ -240,12 +240,10 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
         $conversations = $this->client->conversations()->list($filters);
 
         $this->assertCount(10, $conversations);
-        $this->assertInstanceOf(Conversation::class, $conversations[0]);
-        $this->assertInstanceOf(CustomerThread::class, $conversations[0]['_embedded']['threads'][0]);
+        $this->assertInstanceOf(Conversation::class, $firstConversation = $conversations[0]);
+        $this->assertInstanceOf(CustomerThread::class, $firstConversation->getThreads()->toArray()[0]);
 
-        $this->verifyMultipleRequests([
-            ['GET', 'https://api.helpscout.net/v2/conversations/1'],
-        ]);
+        $this->verifySingleRequest('https://api.helpscout.net/v2/conversations?embed=threads');
     }
 
     public function testListConversations()

--- a/tests/Payloads/ConversationPayloads.php
+++ b/tests/Payloads/ConversationPayloads.php
@@ -18,7 +18,9 @@ class ConversationPayloads
         $totalPages = ceil($totalElements / $pageSize);
 
         // Create embedded resources
-        $conversations = array_map(fn($id) => static::conversation($id, $embedThread), range(1, $pageElements));
+        $conversations = array_map(function ($id) use ($embedThread) {
+            return static::conversation($id, $embedThread);
+        }, range(1, $pageElements));
 
         $data = [
             '_embedded' => [

--- a/tests/Payloads/ConversationPayloads.php
+++ b/tests/Payloads/ConversationPayloads.php
@@ -148,46 +148,57 @@ class ConversationPayloads
         if ($embedThread) {
             $conversation['_embedded']['threads'] = [
                 [
-                    '_embedded' => [
-                        'threads' => [
-                            [
-                                'id' => 1,
-                                'type' => 'lineitem',
-                                'status' => 'closed',
-                                'action' => [
-                                    'type' => 'default',
-                                    'text' => 'John marked as Closed',
-                                    'assiciatedEntities' => [],
-                                ],
-                                'source' => [
-                                    'type' => 'web',
-                                    'via' => 'user',
-                                ],
-                                'createdBy' => [
-                                    'id' => 1,
-                                    'type' => 'user',
-                                    'first' => 'John',
-                                    'last' => 'Doe',
-                                    'email' => 'john.doe@example.com',
-                                    'to' => [],
-                                    'cc' => [],
-                                    'bcc' => [],
-                                    'createdAt' => '2017-04-21T14:39:56Z',
-                                ],
-                                '_embedded' => [
-                                    'attachments' => [],
-                                ],
-                                '_links' => [
-                                    'createdByUser' => [
-                                        'href' => 'https://api.helpscout.net/v2/users/1',
-                                    ]
-                                ]
-                            ],
-                        ],
+                    'id' => 1,
+                    'type' => 'customer',
+                    'status' => 'active',
+                    'state' => 'published',
+                    'action' => [
+                        'type' => 'default',
+                        'associatedEntities' => [],
                     ],
+                    'body' => 'This is a test',
+                    'source' => [
+                        'type' => 'email',
+                        'via' => 'user',
+                    ],
+                    'customer' => [
+                        'id' => 472611182,
+                        'first' => 'John',
+                        'last' => 'Doe',
+                        'photoUrl' => 'https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png',
+                        'email' => 'john.doe@example.com',
+                    ],
+                    'createdBy' => [
+                        'id' => 1,
+                        'type' => 'user',
+                        'first' => 'John',
+                        'last' => 'Doe',
+                        'email' => 'john.doe@example.com',
+                        'to' => [],
+                        'cc' => [],
+                        'bcc' => [],
+                        'createdAt' => '2017-04-21T14:39:56Z',
+                    ],
+                    'assignedTo' => [
+                        'id' => 12,
+                        'first' => 'Help',
+                        'last' => 'Scout',
+                        'email' => 'none@nowhere.com',
+                    ],
+                    'savedReplyId' => 0,
+                    '_embedded' => [
+                        'attachments' => [],
+                    ],
+                    '_links' => [
+                        'createdByUser' => [
+                            'href' => 'https://api.helpscout.net/v2/users/1',
+                        ]
+                    ]
                 ],
             ];
         }
+
+//        var_dump($conversation);
 
         return $conversation;
     }

--- a/tests/Payloads/ConversationPayloads.php
+++ b/tests/Payloads/ConversationPayloads.php
@@ -18,9 +18,7 @@ class ConversationPayloads
         $totalPages = ceil($totalElements / $pageSize);
 
         // Create embedded resources
-        $conversations = array_map(function ($id) use ($embedThread) {
-            return static::conversation($id, $embedThread);
-        }, range(1, $pageElements));
+        $conversations = array_map(fn($id) => static::conversation($id, $embedThread), range(1, $pageElements));
 
         $data = [
             '_embedded' => [
@@ -197,8 +195,6 @@ class ConversationPayloads
                 ],
             ];
         }
-
-//        var_dump($conversation);
 
         return $conversation;
     }

--- a/tests/Payloads/ConversationPayloads.php
+++ b/tests/Payloads/ConversationPayloads.php
@@ -11,15 +11,15 @@ class ConversationPayloads
         return json_encode(static::conversation($id));
     }
 
-    public static function getConversations(int $pageNumber, int $totalElements): string
+    public static function getConversations(int $pageNumber, int $totalElements, bool $embedThread = false): string
     {
         $pageSize = 10;
         $pageElements = min($totalElements, $pageSize);
         $totalPages = ceil($totalElements / $pageSize);
 
         // Create embedded resources
-        $conversations = array_map(function ($id) {
-            return static::conversation($id);
+        $conversations = array_map(function ($id) use ($embedThread) {
+            return static::conversation($id, $embedThread);
         }, range(1, $pageElements));
 
         $data = [
@@ -60,9 +60,9 @@ class ConversationPayloads
         return json_encode($data);
     }
 
-    private static function conversation(int $id): array
+    private static function conversation(int $id, bool $embedThread = false): array
     {
-        return [
+        $conversation = [
             'id' => $id,
             'number' => 15473,
             'threads' => 2,
@@ -144,6 +144,52 @@ class ConversationPayloads
                 ],
             ],
         ];
+
+        if ($embedThread) {
+            $conversation['_embedded']['threads'] = [
+                [
+                    '_embedded' => [
+                        'threads' => [
+                            [
+                                'id' => 1,
+                                'type' => 'lineitem',
+                                'status' => 'closed',
+                                'action' => [
+                                    'type' => 'default',
+                                    'text' => 'John marked as Closed',
+                                    'assiciatedEntities' => [],
+                                ],
+                                'source' => [
+                                    'type' => 'web',
+                                    'via' => 'user',
+                                ],
+                                'createdBy' => [
+                                    'id' => 1,
+                                    'type' => 'user',
+                                    'first' => 'John',
+                                    'last' => 'Doe',
+                                    'email' => 'john.doe@example.com',
+                                    'to' => [],
+                                    'cc' => [],
+                                    'bcc' => [],
+                                    'createdAt' => '2017-04-21T14:39:56Z',
+                                ],
+                                '_embedded' => [
+                                    'attachments' => [],
+                                ],
+                                '_links' => [
+                                    'createdByUser' => [
+                                        'href' => 'https://api.helpscout.net/v2/users/1',
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+        }
+
+        return $conversation;
     }
 
     public static function getThreads(int $conversationId): string


### PR DESCRIPTION
According to the following documentation there is an option to get truncated threads from the conversation API.
See the documentation here: https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/

```
Note: If using the embed=threads parameter with this call, you will see truncated chat threads. This is by design. To view Beacon chat threads in full, call the [List Threads](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/list/) endpoint for that conversation instead.
```

I updated the `ConversationFilters` to allow using the `embed=threads` logic in order to minimize the time it takes for the API to return a response. When I use the `new (ConversationReques())->withThreads()` the api really takes a toll before a response is actually given.