### PR TITLE
Allow setting Guzzle Client options

### DIFF
--- a/src/Http/RestClientBuilder.php
+++ b/src/Http/RestClientBuilder.php
@@ -59,9 +59,10 @@ class RestClientBuilder
     protected function getAuthenticator($tokenRefreshedCallback = null): Authenticator
     {
         $authConfig = $this->config['auth'] ?? [];
+        $guzzleConfig = $this->config['guzzle'] ?? [];
 
         $authenticator = new Authenticator(
-            new Client(),
+            new Client($guzzleConfig),
             $this->getAuthClass($authConfig)
         );
 
@@ -95,10 +96,11 @@ class RestClientBuilder
 
     protected function getOptions(): array
     {
-        return [
+        $guzzleConfig = $this->config['guzzle'] ?? [];
+        return array_merge($guzzleConfig, [
             'handler' => $this->getHandlerStack(),
             'http_errors' => false,
-        ];
+        ]);
     }
 
     protected function getHandlerStack(): HandlerStack


### PR DESCRIPTION
Resolves https://github.com/helpscout/helpscout-api-php/issues/271

# Current behavior
It's not possible to set options for the Guzzle client used by the SDK.

# Goal
Allow developers to easily set config options for the Guzzle Client, like timeout values, proxies or `on_stats` handlers (and other [default request options](https://docs.guzzlephp.org/en/latest/request-options.html)).

With the guzzle default values, the current default timeout is 0 (indefinitely) which can be an issue e.g. for synchronous use-cases.

# Usage
```
$guzzleOptions = [
    'timeout' => 10,
    'on_stats' => function (TransferStats $stats) {
        // e.g. log statistics from helpscout api requests
    },
    // ...more options available, see https://docs.guzzlephp.org/en/latest/request-options.html
];

$client = ApiClientFactory::createClient([
    'guzzle' => $guzzleOptions,
    // 'auth' is another already existing keyword here for Authenticator options
]);
```