### PR TITLE
Allow update to rize/uri-template library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3|^8.0",
         "webmozart/assert": "^1.2",
         "guzzlehttp/guzzle": "^6.3|^7.0.1",
-        "rize/uri-template": "0.3.5"
+        "rize/uri-template": "^0.3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",


### PR DESCRIPTION
rize/uri-template was previously locked to 0.3.5, this change allows updating to 0.3.6