### PR TITLE
Fix ConversationsEndpoint publishDraft function

### DIFF
--- a/src/Conversations/ConversationsEndpoint.php
+++ b/src/Conversations/ConversationsEndpoint.php
@@ -177,7 +177,7 @@ class ConversationsEndpoint extends Endpoint
 
     public function publishDraft(int $conversationId): void
     {
-        $patch = Patch::replace('draft', true);
+        $patch = Patch::replace('draft', false);
         $this->patchConversation($conversationId, $patch);
     }
 

--- a/tests/Conversations/ConversationIntegrationTest.php
+++ b/tests/Conversations/ConversationIntegrationTest.php
@@ -381,7 +381,7 @@ class ConversationIntegrationTest extends ApiClientIntegrationTestCase
         $this->verifyRequestWithData('https://api.helpscout.net/v2/conversations/1', 'PATCH', [
             'op' => 'replace',
             'path' => '/draft',
-            'value' => true,
+            'value' => false,
         ]);
     }
 


### PR DESCRIPTION
Previously this function was taking a draft conversation and making it... draft. It now changes it from draft to published and actually sends.