### PR TITLE
Make use of timing-safe functions to compare HMAC signatures

### DIFF
--- a/src/Webhooks/IncomingWebhook.php
+++ b/src/Webhooks/IncomingWebhook.php
@@ -78,7 +78,7 @@ class IncomingWebhook
         $signature = $this->generateSignature();
         $header = $this->findHeader(self::SIGNATURE_HEADERS);
 
-        if ($signature !== $header) {
+        if (hash_equals($signature, $header) === false) {
             throw new InvalidSignatureException($signature, $header);
         }
     }


### PR DESCRIPTION
Basic string comparisons are not timing-safe for validating HMAC signatures. PHP has a built in function (`hash_equals`) that is timing-safe.

There are parts of the official Help Scout documentation that should be updated to make use of constant-time string comparisons for validating signatures.

https://developer.helpscout.com/webhooks/
https://developer.helpscout.com/apps/guides/signature-validation/