### PR TITLE
feat(thread): Implemented associatedEntities functionality

### DIFF
--- a/src/Conversations/Threads/Thread.php
+++ b/src/Conversations/Threads/Thread.php
@@ -63,6 +63,11 @@ class Thread implements Extractable, Hydratable
     private $assignedTo;
 
     /**
+     * @var array|null
+     */
+    private $associatedEntities;
+
+    /**
      * @var int|null
      */
     private $savedReplyId;
@@ -116,6 +121,7 @@ class Thread implements Extractable, Hydratable
         if (isset($data['action'])) {
             $this->actionType = $data['action']['type'] ?? null;
             $this->actionText = $data['action']['text'] ?? null;
+            $this->associatedEntities = $data['action']['associatedEntities'] ?? null;
         }
 
         if (isset($data['source']) && is_array($data['source'])) {
@@ -192,6 +198,14 @@ class Thread implements Extractable, Hydratable
             ];
         }
 
+        if ($this->wasMerged()) {
+            $data['action'] = [
+                'type' => $this->getActionType(),
+                'text' => $this->getActionText(),
+                'associatedEntities' => $this->getAssociatedEntities(),
+            ];
+        }
+
         if ($this->wasCreatedByCustomer()) {
             $data['createdBy'] = [
                 'id' => $this->getCreatedByCustomer()->getId(),
@@ -265,6 +279,11 @@ class Thread implements Extractable, Hydratable
         return \is_string($this->actionText);
     }
 
+    public function wasMerged(): bool
+    {
+        return $this->actionType === 'merged';
+    }
+
     public function getActionType(): ?string
     {
         return $this->actionType;
@@ -295,6 +314,11 @@ class Thread implements Extractable, Hydratable
     public function getAssignedTo(): ?array
     {
         return $this->assignedTo;
+    }
+
+    public function getAssociatedEntities(): ?array
+    {
+        return $this->associatedEntities;
     }
 
     public function getTo(): ?array

--- a/tests/Conversations/Threads/ThreadTest.php
+++ b/tests/Conversations/Threads/ThreadTest.php
@@ -93,6 +93,28 @@ class ThreadTest extends TestCase
         $this->assertTrue($thread->isImported());
     }
 
+    public function testHydrateAssociatedEntities()
+    {
+        $thread = new Thread();
+        $thread->hydrate([
+            'id' => 12,
+            'type' => 'lineitem',
+            'action' => [
+                'type' => 'merged',
+                'text' => 'You merged threads from another conversation',
+                'associatedEntities' => $associatedEntities = [
+                    'originalConversation' => '12345',
+                ],
+            ]
+        ]);
+
+        $this->assertSame(12, $thread->getId());
+        $this->assertSame('lineitem', $thread->getType());
+        $this->assertSame('merged', $thread->getActionType());
+        $this->assertSame('You merged threads from another conversation', $thread->getActionText());
+        $this->assertSame($associatedEntities, $thread->getAssociatedEntities());
+    }
+
     public function testHydrateTextFromBody()
     {
         $thread = new Thread();


### PR DESCRIPTION
* PHP version: 8.4
* SDK version: 3.10.2

**Current behavior**:
Currently I am unable to fetch the `associatedEntities` data from the `Thread` object.


**Changed behavior**:
Implemented some logic to hydrate and extract/get the `associatedEntities` data from the `Thread` object. Main reason for this implementation is because of the `convo.merged` webhook utilizing this field within the dataset which I need to hook into to resolve some stuff on my end.

**Changes proposed in this pull request:**
- Add new `associatedEntities` property for the `Thread` object.
- Implemented logic to extra the data within the `hydrate` method.
- Add getter.
- Add helper `wasMerged` method used within `ThreadTest` to help keeping the test logical.
- Updated `ThreadTest`.
