### PR TITLE
Modernize required libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,12 @@
         "mockery/mockery": "^1.1",
         "ramsey/uuid": "^4.1"
     },
+    "replace": {
+        "symfony/polyfill-php74": "*",
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php82": "*"
+    },
     "autoload": {
         "psr-4": { "HelpScout\\Api\\": "src/" }
     },

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "webmozart/assert": "^1.2",
-        "guzzlehttp/guzzle": "^6.3|^7.0.1",
-        "rize/uri-template": "^0.3.5|^0.4.0"
+        "php": "^8.2",
+        "webmozart/assert": "^2.0",
+        "guzzlehttp/guzzle": "^7.0",
+        "rize/uri-template": "^0.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.4",
+        "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.4",
         "mockery/mockery": "^1.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="coverage-html" target="build/reports/phpunit"/>
-    </logging>
-
-    <php>
-        <ini name="error_reporting" value="-1" />
-        <ini name="date.timezone" value="UTC" />
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/reports/phpunit"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <ini name="date.timezone" value="UTC"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Assert/Assert.php
+++ b/src/Assert/Assert.php
@@ -12,9 +12,9 @@ class Assert extends BaseAssert
     /**
      * {@inheritdoc}
      *
-     * @return InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    protected static function reportInvalidArgument($message)
+    protected static function reportInvalidArgument(string $message): never
     {
         throw new InvalidArgumentException($message);
     }

--- a/tests/Conversations/ConversationFiltersTest.php
+++ b/tests/Conversations/ConversationFiltersTest.php
@@ -99,7 +99,7 @@ class ConversationFiltersTest extends TestCase
         ], $filters->getParams());
     }
 
-    public function sortFieldProvider(): array
+    public static function sortFieldProvider(): array
     {
         return [
             ['createdAt'],
@@ -133,7 +133,7 @@ class ConversationFiltersTest extends TestCase
         ], $filters->getParams());
     }
 
-    public function sortOrderProvider(): array
+    public static function sortOrderProvider(): array
     {
         return [
             ['asc', 'asc'],

--- a/tests/Conversations/ConversationRequestTest.php
+++ b/tests/Conversations/ConversationRequestTest.php
@@ -23,7 +23,7 @@ class ConversationRequestTest extends TestCase
         $this->assertTrue($request->hasLink($rel));
     }
 
-    public function linkProvider()
+    public static function linkProvider()
     {
         return [
             [ConversationLinks::MAILBOX],

--- a/tests/Customers/CustomerFiltersTest.php
+++ b/tests/Customers/CustomerFiltersTest.php
@@ -60,7 +60,7 @@ class CustomerFiltersTest extends TestCase
         ], $filters->getParams());
     }
 
-    public function sortFieldProvider(): array
+    public static function sortFieldProvider(): array
     {
         return [
             ['score'],
@@ -90,7 +90,7 @@ class CustomerFiltersTest extends TestCase
         ], $filters->getParams());
     }
 
-    public function sortOrderProvider(): array
+    public static function sortOrderProvider(): array
     {
         return [
             ['asc', 'asc'],

--- a/tests/Customers/CustomerRequestTest.php
+++ b/tests/Customers/CustomerRequestTest.php
@@ -23,7 +23,7 @@ class CustomerRequestTest extends TestCase
         $this->assertTrue($request->hasLink($rel));
     }
 
-    public function linkProvider()
+    public static function linkProvider()
     {
         return [
             [CustomerLinks::ADDRESS],

--- a/tests/Http/AuthenticatorTest.php
+++ b/tests/Http/AuthenticatorTest.php
@@ -188,7 +188,7 @@ class AuthenticatorTest extends TestCase
         );
     }
 
-    public function autoRefreshAccessTokenProvider(): \Generator
+    public static function autoRefreshAccessTokenProvider(): \Generator
     {
         $typesThatCanRefreshTokens = [
             ClientCredentials::TYPE,

--- a/tests/Http/RestClientTest.php
+++ b/tests/Http/RestClientTest.php
@@ -193,7 +193,7 @@ class RestClientTest extends TestCase
         $this->assertFalse($shouldRetry);
     }
 
-    public function noRetryParamProvider(): \Generator
+    public static function noRetryParamProvider(): \Generator
     {
         $request = new Request(
             'POST',
@@ -272,7 +272,7 @@ class RestClientTest extends TestCase
         $this->assertTrue($shouldRetry);
     }
 
-    public function retryParamProvider(): \Generator
+    public static function retryParamProvider(): \Generator
     {
         $request = new Request(
             'POST',

--- a/tests/Mailboxes/MailboxRequestTest.php
+++ b/tests/Mailboxes/MailboxRequestTest.php
@@ -23,7 +23,7 @@ class MailboxRequestTest extends TestCase
         $this->assertTrue($request->hasLink($rel));
     }
 
-    public function linkProvider()
+    public static function linkProvider()
     {
         return [
             [MailboxLinks::FIELDS],

--- a/tests/ReflectionTestTrait.php
+++ b/tests/ReflectionTestTrait.php
@@ -19,7 +19,6 @@ trait ReflectionTestTrait
 
         $reflection = new \ReflectionClass($class);
         $reflectedMethod = $reflection->getMethod($method);
-        $reflectedMethod->setAccessible(true);
 
         return $reflectedMethod->invokeArgs($object, $parameters);
     }
@@ -35,7 +34,6 @@ trait ReflectionTestTrait
     {
         $reflection = new \ReflectionClass($object);
         $property = $reflection->getProperty($attributeName);
-        $property->setAccessible(true);
 
         return $property->getValue($object);
     }
@@ -51,7 +49,6 @@ trait ReflectionTestTrait
         $class = $this->getClassName($object);
 
         $reflection = new \ReflectionProperty($class, $attributeName);
-        $reflection->setAccessible(true);
         $reflection->setValue($object, $value);
     }
 

--- a/tests/Reports/ReportTest.php
+++ b/tests/Reports/ReportTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ReportTest extends TestCase
 {
-    public function reportTypeProvider(): array
+    public static function reportTypeProvider(): array
     {
         return [
             [Reports\Company\Overall::class],


### PR DESCRIPTION
Some of the Composer dependencies are getting very long in the tooth (we recently ran into a dependency problem because of the old version of `webmozart/assert`.) This PR updates versions of required dependencies to (mostly) current ones; consequently it also changes the minimum version of PHP required. This shouldn't be a problem now that 8.2 is the oldest still supported version, but will I assume require a new major release.

The exception is `phpunit/phpunit` which is only updated to version 10. There are some deprecations that should be sorted out by someone who is more familiar with PHPUnit before an update to version 11.