### PR TITLE
Add hasNextPage()/hasPreviousPage() to PagedCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,6 +1023,10 @@ $users->getPageNumber();
 // The total number of pages
 $users->getTotalPageCount();
 
+// Whether a next/previous page is available
+$users->hasNextPage();
+$users->hasPreviousPage();
+
 // Load the next page
 $nextUsers = $users->getNextPage();
 
@@ -1041,6 +1045,24 @@ $otherUsers = $users->getPage(12);
 // Paged results are accessible as normal arrays, so you can simply iterate over them
 foreach ($otherUsers as $user) {
     echo $user->getFirstName();
+}
+```
+
+To walk every page, drive the loop with `hasNextPage()` rather than comparing the page number against `getTotalPageCount()`. The total is a snapshot from the response that produced it, while `hasNextPage()` reflects whether the API returned a `next` link for the current page — so the loop stays correct even if the underlying result set changes between requests.
+
+```php
+$page = $client->users()->list();
+
+while (true) {
+    foreach ($page as $user) {
+        echo $user->getFirstName();
+    }
+
+    if (!$page->hasNextPage()) {
+        break;
+    }
+
+    $page = $page->getNextPage();
 }
 ```
 

--- a/src/Entity/PagedCollection.php
+++ b/src/Entity/PagedCollection.php
@@ -74,9 +74,29 @@ class PagedCollection extends Collection
         return $this->loadPage($this->links->expand(self::REL_PAGE, [self::PAGE_VARIABLE => $number]));
     }
 
+    /**
+     * Whether this page advertises a next page.
+     *
+     * Prefer this over comparing getPageNumber() against getTotalPageCount() when looping:
+     * the link is recomputed by the API for every response and reflects the result set as it
+     * exists right now, whereas a total-page count captured from an earlier page goes stale if
+     * the underlying set shrinks between requests (e.g. items leaving a status/folder filter
+     * while you paginate). Driving the loop off this check avoids getNextPage() throwing
+     * "The link 'next' was not found" once the result set no longer reaches the expected page.
+     */
+    public function hasNextPage(): bool
+    {
+        return $this->links->has(HalLink::REL_NEXT);
+    }
+
     public function getNextPage(): self
     {
         return $this->loadPage($this->links->getHref(HalLink::REL_NEXT));
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->links->has(HalLink::REL_PREVIOUS);
     }
 
     public function getPreviousPage(): self

--- a/src/Entity/PagedCollection.php
+++ b/src/Entity/PagedCollection.php
@@ -74,16 +74,6 @@ class PagedCollection extends Collection
         return $this->loadPage($this->links->expand(self::REL_PAGE, [self::PAGE_VARIABLE => $number]));
     }
 
-    /**
-     * Whether this page advertises a next page.
-     *
-     * Prefer this over comparing getPageNumber() against getTotalPageCount() when looping:
-     * the link is recomputed by the API for every response and reflects the result set as it
-     * exists right now, whereas a total-page count captured from an earlier page goes stale if
-     * the underlying set shrinks between requests (e.g. items leaving a status/folder filter
-     * while you paginate). Driving the loop off this check avoids getNextPage() throwing
-     * "The link 'next' was not found" once the result set no longer reaches the expected page.
-     */
     public function hasNextPage(): bool
     {
         return $this->links->has(HalLink::REL_NEXT);

--- a/tests/Entity/PagedCollectionTest.php
+++ b/tests/Entity/PagedCollectionTest.php
@@ -72,10 +72,68 @@ class PagedCollectionTest extends TestCase
         $this->assertSame('https://api.helpscout.com/v2/customers?page=3', $this->getLoadedUri());
     }
 
+    public function testHasNextPageReflectsLinkPresence()
+    {
+        $this->assertTrue($this->collection->hasNextPage());
+
+        $lastPage = new PagedCollection(
+            range(1, 5),
+            new HalPageMetadata(4, 10, 35, 4),
+            new HalLinks([
+                new HalLink('page', 'https://api.helpscout.com/v2/customers{?page}', true),
+                new HalLink('first', 'https://api.helpscout.com/v2/customers?page=1', false),
+                new HalLink('last', 'https://api.helpscout.com/v2/customers?page=4', false),
+                new HalLink('previous', 'https://api.helpscout.com/v2/customers?page=3', false),
+            ]),
+            $this->pageLoader
+        );
+
+        $this->assertFalse($lastPage->hasNextPage());
+    }
+
+    public function testHasNextPageIsFalseWhenLinkAbsentDespiteUnexhaustedPageCount()
+    {
+        // Page 2 of a reported 4, but the API omitted the `next` link because the result set
+        // shrank underneath the pagination — the bug scenario from SDS-11533. hasNextPage()
+        // must report the truth (no next) rather than trusting the stale total-page count.
+        $collection = new PagedCollection(
+            range(1, 10),
+            new HalPageMetadata(2, 10, 35, 4),
+            new HalLinks([
+                new HalLink('page', 'https://api.helpscout.com/v2/customers{?page}', true),
+                new HalLink('first', 'https://api.helpscout.com/v2/customers?page=1', false),
+                new HalLink('previous', 'https://api.helpscout.com/v2/customers?page=1', false),
+            ]),
+            $this->pageLoader
+        );
+
+        $this->assertLessThan($collection->getTotalPageCount(), $collection->getPageNumber());
+        $this->assertFalse($collection->hasNextPage());
+    }
+
     public function testPreviousPage()
     {
         $this->assertSame($this->loadedCollection, $this->collection->getPreviousPage());
         $this->assertSame('https://api.helpscout.com/v2/customers?page=1', $this->getLoadedUri());
+    }
+
+    public function testHasPreviousPageReflectsLinkPresence()
+    {
+        $this->assertTrue($this->collection->hasPreviousPage());
+
+        $firstPage = new PagedCollection(
+            range(1, 10),
+            new HalPageMetadata(1, 10, 35, 4),
+            new HalLinks([
+                new HalLink('page', 'https://api.helpscout.com/v2/customers{?page}', true),
+                new HalLink('first', 'https://api.helpscout.com/v2/customers?page=1', false),
+                new HalLink('last', 'https://api.helpscout.com/v2/customers?page=4', false),
+                new HalLink('next', 'https://api.helpscout.com/v2/customers?page=2', false),
+            ]),
+            $this->pageLoader
+        );
+
+        $this->assertFalse($firstPage->hasPreviousPage());
     }
 
     public function testFirstPage()


### PR DESCRIPTION
## Why

Pagination loops that guard on `getPageNumber() < getTotalPageCount()` can throw `The link "next" was not found` from `getNextPage()`. The total-page count is a point-in-time snapshot, while the `next` link is recomputed per response and reflects the result set as it currently exists. If the underlying set changes between requests (e.g. items leaving a filter while paginating), the live `next` link can disappear before the cached page count is exhausted.

The SDK previously exposed only `getNextPage()` (which throws) and `getTotalPageCount()`, leaving no safe way to check for a next page.

## What

Additive, non-breaking:

- `PagedCollection::hasNextPage(): bool`
- `PagedCollection::hasPreviousPage(): bool`

This lets callers drive the loop off the live link instead of a snapshotted count:

```php
while ($collection->hasNextPage()) {
    $collection = $collection->getNextPage();
}
```

## Tests

`PagedCollectionTest` covers link-present and link-absent cases, including a `next`-link-absent page whose page number is still below the total page count.